### PR TITLE
feat(api): disable cash-redemption endpoints (Cashfree + BulkPe)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,22 @@ This Express/Jest backend powers Aultra Paints services. Use the guidance below 
   - `sync-accounts.js`
   - `update-dealer-salesexec.js`
 - Postman assets were refreshed in `postman/AULTRA-PAINTS-LOCAL.postman_collection.json`.
+
+## Cash redemption — DISABLED (as of 2026-04-26)
+Points-to-INR cash payouts via Cashfree and BulkPe payment gateways have been retired. Live entry points are gone; record-keeping artifacts remain on disk for historical queries.
+
+- **Disabled routes** (every method/path under these returns HTTP 410 Gone with `{ success:false, code:'CASH_REDEMPTION_DISABLED', message:'…' }`):
+  - `routes/cashFreeRoutes.js` mounted at `/cashFree/*`
+  - `routes/bulkPeRoutes.js` mounted at `/bulkPe/*`
+  - Both files collapsed to a single `router.all('/*', …)` that logs the hit (`utils/logger`) and returns the disabled payload.
+- **Disabled cron**: the `crons/UpdatePendingCashFreeTransfers.js` registration was removed from `config/express.js` (the require line is commented out). The cron file remains on disk for history but no longer runs.
+- **Preserved on disk** (no live entry points; kept for transactional record-keeping queries):
+  - `controllers/cashFreeController.js`
+  - `services/cashFreePaymentService.js`, `services/bulkPePaymentService.js`
+  - `models/CashFreeTransaction.js`
+  - `utils/Cashfree.js`
+  - `crons/UpdatePendingCashFreeTransfers.js`
+  - `mongoscripts/updateUserRedemptions.js`
+- **Unaffected**: `routes/transfer.route.js` (`/transfer/toDealer`) is points-to-points only and is the recommended replacement path.
+
+When changing related code, treat the gateway integrations as read-only history. Do not re-mount the disabled routes or re-register the cron without an explicit product decision.

--- a/config/express.js
+++ b/config/express.js
@@ -10,7 +10,9 @@ const cors = require('cors');
 const helmet = require('helmet');
 const routes = require('../routes/index');
 const passport = require('../middleware/passport');
-const scheduler = require('../crons/UpdatePendingCashFreeTransfers');
+// Cash-redemption cron disabled — cron file preserved on disk for history but
+// no longer required (would re-arm the retired Cashfree status-poll job).
+// const scheduler = require('../crons/UpdatePendingCashFreeTransfers');
 const { SESSION_SECRET, IS_PROD } = require('./secrets');
 
 const requestContext = require('../utils/requestContext');

--- a/routes/bulkPeRoutes.js
+++ b/routes/bulkPeRoutes.js
@@ -1,105 +1,26 @@
+// BulkPe cash-redemption endpoints — DISABLED.
+//
+// Cash redemption (points → INR via BulkPe UPI payouts) was retired alongside
+// the Cashfree path. All previously-mounted endpoints under `/bulkPe/*` now
+// return HTTP 410 Gone with a stable JSON error payload. The full
+// implementation is preserved in git history.
+
 const express = require('express');
 const router = express.Router();
 const logger = require('../utils/logger');
-const CashFreeTransaction = require('../models/CashFreeTransaction');
-const BulkPePaymentService = require("../services/bulkPePaymentService");
 
-async function processPayload(payload) {
-    // Validate required fields
-    if (!payload?.data?.reference_id) {
-        logger.error('Webhook missing reference_id', payload);
-    }
-
-    const refId = payload.data.reference_id;
-
-    // Find existing transaction by transfer_id
-    const transaction = await CashFreeTransaction.findOne({ transfer_id: refId });
-
-    if (!transaction) {
-        logger.warn(`No transaction found for reference_id: ${refId}. Creating fallback record.`);
-
-        // Create fallback if not found, so it’s trackable
-        const fallback = new CashFreeTransaction({
-            transfer_id: refId,
-            cf_transfer_id: payload.data?.transcation_id || payload.data?.transaction_id || '',
-            status: payload.data?.trx_status || '',
-            status_code: payload.data?.trx_message.toString() || '',
-            status_description: payload.data?.trx_message || payload?.message || '',
-            beneficiary_details: {
-                beneCode: '',
-                beneName: payload.data?.beneficiaryName || '',
-                beneAccNum: payload.data?.account_number || '',
-                beneIfscCode: payload.data?.ifsc || '',
-                beneAcType: ''
-            },
-            transfer_amount: payload.data?.amount || 0,
-            transfer_mode: payload.data?.payment_mode || 'UPI',
-            transfer_utr: payload.data?.utr || '',
-            added_on: payload.data?.createdAt || new Date().toISOString(),
-            updated_on: payload.data?.updatedAt || new Date().toISOString(),
-            event_time: new Date().toISOString(),
-            event_type: payload.data?.type || 'Debit'
-        });
-
-        await fallback.save();
-        return;
-    }
-
-    // Update the transaction
-    transaction.cf_transfer_id = payload.data?.transcation_id || transaction.cf_transfer_id;
-    transaction.status = payload.data?.trx_status || transaction.status;
-    transaction.status_code = payload.data?.trx_message?.toString() || transaction.status_code || '';
-    transaction.status_description = payload.data?.trx_message || payload?.message || transaction.status_description;
-    transaction.beneficiary_details = {
-        ...transaction.beneficiary_details,
-        beneName: payload.data?.beneficiaryName || transaction.beneficiary_details?.beneName,
-        beneAccNum: payload.data?.account_number || transaction.beneficiary_details?.beneAccNum,
-        beneIfscCode: payload.data?.ifsc || transaction.beneficiary_details?.beneIfscCode,
-    };
-    transaction.transfer_amount = payload.data?.amount || transaction.transfer_amount;
-    transaction.transfer_mode = payload.data?.payment_mode || transaction.transfer_mode;
-    transaction.transfer_utr = payload.data?.utr || transaction.transfer_utr;
-    transaction.updated_on = payload.data?.updatedAt || new Date().toISOString();
-    transaction.event_time = new Date().toISOString();
-    transaction.event_type = 'WEBHOOK_UPDATE';
-
-    await transaction.save();
-
-    logger.info(`Transaction updated for reference_id: ${refId}`, {
-        status: transaction.status,
-        utr: transaction.transfer_utr
-    });
-}
-
-router.post('/webhooks/receive/success', async (req, res) => {
-    try {
-        logger.info('webhook headers', { headers: req.headers });
-        logger.info('Received webhook payload', { body: req.body });
-
-        processPayload(req.body);
-
-        return res.status(200).json({ message: 'Transaction updated successfully.' });
-    } catch (error) {
-        logger.error('Error processing webhook', { error: error.message, body: req.body });
-
-        return res.status(500).json({
-            message: 'Internal Server Error while processing webhook'
-        });
-    }
+const DISABLED_RESPONSE = Object.freeze({
+    success: false,
+    code: 'CASH_REDEMPTION_DISABLED',
+    message: 'Cash redemption is no longer available. Please use points-to-dealer transfer instead.',
 });
 
-router.post('/testUPIPayment', async (req, res) => {
-    try {
-        const { upi, name, cash } = req.body;
-        const paymentResult = await BulkPePaymentService.upiPayment(upi, name, cash);
-        if (paymentResult.success) {
-            res.status(200).json({ success: true, message: paymentResult.message });
-        } else {
-            res.status(400).json({ success: false, message: paymentResult.message, data: paymentResult.data });
-        }
-    } catch (error) {
-        res.status(500).json({ success: false, message: error.message });
-    }
+router.all('/*', (req, res) => {
+    logger.warn(
+        `Disabled BulkPe endpoint hit: ${req.method} ${req.originalUrl}`,
+        { ip: req.ip, userId: req.user && req.user._id },
+    );
+    return res.status(410).json(DISABLED_RESPONSE);
 });
 
 module.exports = router;

--- a/routes/cashFreeRoutes.js
+++ b/routes/cashFreeRoutes.js
@@ -1,99 +1,27 @@
+// Cashfree cash-redemption endpoints — DISABLED.
+//
+// Cash redemption (points → INR via Cashfree payouts) was retired.
+// All previously-mounted endpoints under `/cashFree/*` now return HTTP 410 Gone
+// with a stable JSON error payload. The full implementation is preserved in
+// git history (and the controllers/services/model files remain on disk for
+// transactional record-keeping queries) but no live entry-point exists.
+
 const express = require('express');
 const router = express.Router();
-const cashFreePaymentService = require('../services/cashFreePaymentService');
-const { getAllTransactions } = require('../controllers/cashFreeController');
-const passport = require("../middleware/passport");
-const Cashfree = require('../utils/Cashfree');
-const CashFreeTransaction = require('../models/CashFreeTransaction');
 const logger = require('../utils/logger');
-const bodyParser = require('body-parser');
-const cashFreeController = require('../controllers/cashFreeController');
 
-// Test Payment Processing Endpoint
-router.post('/testPayment', async (req, res) => {
-    try {
-        const { mobile, name, cash } = req.body;
-        const paymentResult = await cashFreePaymentService.pay2Phone(mobile, name, cash);
-        if (paymentResult.success) {
-            res.status(200).json({ success: true, message: paymentResult.message });
-        } else {
-            res.status(400).json({ success: false, message: paymentResult.message, data: paymentResult.data });
-        }
-    } catch (error) {
-        res.status(500).json({ success: false, message: error.message });
-    }
+const DISABLED_RESPONSE = Object.freeze({
+    success: false,
+    code: 'CASH_REDEMPTION_DISABLED',
+    message: 'Cash redemption is no longer available. Please use points-to-dealer transfer instead.',
 });
 
-router.post('/testUPIPayment', async (req, res) => {
-    try {
-        const { upi, mobile, cash } = req.body;
-        const paymentResult = await cashFreePaymentService.upiPayment(upi, mobile, cash);
-        if (paymentResult.success) {
-            res.status(200).json({ success: true, message: paymentResult.message });
-        } else {
-            res.status(400).json({ success: false, message: paymentResult.message, data: paymentResult.data });
-        }
-    } catch (error) {
-        res.status(500).json({ success: false, message: error.message });
-    }
+router.all('/*', (req, res) => {
+    logger.warn(
+        `Disabled Cashfree endpoint hit: ${req.method} ${req.originalUrl}`,
+        { ip: req.ip, userId: req.user && req.user._id },
+    );
+    return res.status(410).json(DISABLED_RESPONSE);
 });
-
-// Custom middleware to capture raw body before JSON parsing
-const rawBodyMiddleware = (req, res, buf, encoding) => {
-    req.rawBody = buf.toString();
-    console.log('raw body ----- ', req.rawBody);// Store exact raw body
-};
-
-router.post('/webhooks/receive',
-    bodyParser.json({ verify: rawBodyMiddleware }),
-    async (req, res) => {
-    try {
-        console.log('Received webhooks events response --- ', req.body);
-        console.log('Received webhooks events response raw --- ', req.rawBody);
-        //req.rawBody = req.body.toString();
-        const signature = req.header('x-webhook-signature') ? req.header('x-webhook-signature') : req.body.signature;
-        const rawBody = JSON.stringify(req.body);
-        const timestamp = req.header('x-webhook-timestamp') ? req.header('x-webhook-timestamp') : req.body.alertTime;
-
-        const PayoutWebhookEvent =  Cashfree.PayoutVerifyWebhookSignature(signature, rawBody, timestamp);
-        logger.info('PayoutWebhookEvent --- ', PayoutWebhookEvent);
-        const eventData = PayoutWebhookEvent.object.data;
-        const eventTime = PayoutWebhookEvent.object.event_time;
-        const eventType = PayoutWebhookEvent.object.type;
-        const cashFreeTransaction = await CashFreeTransaction.findOneAndUpdate(
-            {
-                transfer_id: eventData.transfer_id,
-                cf_transfer_id: eventData.cf_transfer_id
-            },{
-                $set: {
-                    status: eventData.status,
-                    status_code: eventData.status_code,
-                    status_description: eventData.status_description,
-                    transfer_service_charge: eventData.transfer_service_charge ? eventData.transfer_service_charge : null,
-                    transfer_service_tax: eventData.transfer_service_tax ? eventData.transfer_service_tax : null,
-                    transfer_utr: eventData.transfer_utr ? eventData.transfer_utr : null,
-                    fundsource_id: eventData.fundsource_id ? eventData.fundsource_id : null,
-                    added_on: eventData.added_on,
-                    updated_on: eventData.updated_on,
-                    event_time: eventTime,
-                    event_type: eventType
-                }
-            }
-        );
-    } catch (error) {
-        console.error('Error while receiving webhooks events from CashFree --- ', error);
-    } finally {
-        return res.status(200).json({message: 'Webhook received.'});
-    }
-});
-
-router.use(passport.authenticate('jwt', { session: false }));
-
-// Get all cash free transactions
-router.get('/getTransactions', getAllTransactions);
-
-
-// Get available balance from BulkPe
-router.get('/fetchBulkPeBalance', cashFreeController.getAvailableBalance);
 
 module.exports = router;


### PR DESCRIPTION
Cash redemption (points → INR via payment-gateway payouts) was retired. All routes under /cashFree/* and /bulkPe/* now return HTTP 410 Gone with a stable JSON payload:

  {
    "success": false,
    "code": "CASH_REDEMPTION_DISABLED",
    "message": "Cash redemption is no longer available..."
  }

- routes/cashFreeRoutes.js: collapsed to a single router.all('/*') that logs the hit and returns the disabled-response payload
- routes/bulkPeRoutes.js: same shape
- config/express.js: stop registering the Cashfree status-poll cron (UpdatePendingCashFreeTransfers); cron file kept on disk for history

Preserved on disk for transactional record-keeping queries (no live entry points): controllers/cashFreeController.js, services/cashFreePayment-/ bulkPePaymentService.js, models/CashFreeTransaction.js, utils/Cashfree.js, mongoscripts/updateUserRedemptions.js.