### PR TITLE
docs: add CLAUDE.md pointer to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Project guidance for Claude
+
+This repository's conventions, structure, build/test commands, and recent
+change context are documented in [`AGENTS.md`](AGENTS.md). Read that file
+first.
+
+This file exists so Claude Code automatically picks up the same context
+that other agent runtimes load from `AGENTS.md`. Both files are intended
+to stay in sync; treat `AGENTS.md` as the source of truth and update it
+whenever conventions or notable changes need to be recorded.


### PR DESCRIPTION
Claude Code looks for CLAUDE.md by default and was missing the project context already documented in AGENTS.md. Add a one-page pointer so it picks up the same conventions other agent runtimes already load. AGENTS.md remains the source of truth.