### PR TITLE
feat: product offer thumbnails, Focus8 cache, and N+1 price query fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,25 @@ SuperUser-only feature allowing admins to issue credit notes against a dealer's 
 
 ---
 
+### Product Offers — image thumbnails (as of 2026-04-28)
+On create and update, the server generates a 300 px-wide PNG thumbnail alongside the full-resolution original and stores both in the same DigitalOcean Spaces bucket (`AWS_BUCKET_PRODUCT_OFFER`).
+
+**New dependency:** `sharp` — native image-processing library used for thumbnail generation. Must be present in `node_modules` after `npm install`.
+
+**Changed files:**
+- `models/productOffers.model.js` — added `productOfferThumbnailUrl: { type: String }` field (optional; undefined on legacy docs).
+- `controllers/productOffers.controller.js`:
+  - Added `sharp` import and private `generateThumbnail(imageBuffer)` helper: resizes to 300 px width (proportional height, `withoutEnlargement: true`), outputs PNG.
+  - `createProductOffer` — after uploading the original (`{offerId}.png`), calls `generateThumbnail` and uploads `{offerId}_thumbnail.png`; `updateOne` now sets both `productOfferImageUrl` and `productOfferThumbnailUrl`.
+  - `updateProductOffer` — when a new image is provided, deletes the old original **and** old thumbnail from S3 before uploading replacements; `productOfferThumbnailUrl` is included in the `findByIdAndUpdate` payload.
+
+**New script:**
+- `scripts/backfill-product-offer-thumbnails.js` — one-shot script to backfill thumbnails for existing offers that pre-date this change. Queries documents where `productOfferImageUrl` is set but `productOfferThumbnailUrl` is absent, downloads each original from DigitalOcean, generates a thumbnail with `sharp`, uploads it, and saves the URL. Idempotent — safe to re-run. Run with: `node scripts/backfill-product-offer-thumbnails.js`.
+
+**Mobile API contract:** both `productOfferImageUrl` (full resolution) and `productOfferThumbnailUrl` (300 px wide) are returned in all product-offer read endpoints. Mobile should use the thumbnail for list/card previews and fall back to `productOfferImageUrl` when `productOfferThumbnailUrl` is absent (legacy docs).
+
+---
+
 ### Product Offers — multi-select route scheme + SuperUser visibility + sort order
 - `models/productOffers.model.js` — `routeScheme` type changed from `String` to `[String]` (default `null`). MongoDB's element-match means existing single-string `{ routeScheme: "mobile" }` queries still work for both legacy String docs and new Array docs without a query change.
 - `controllers/productOffers.controller.js`:
@@ -87,15 +106,15 @@ SuperUser-only feature allowing admins to issue credit notes against a dealer's 
 
 ---
 
-### Test suite fixes and additions (as of 2026-04-26)
-All 102 tests across 6 suites pass (`npx jest tests/controllers/ --no-coverage`).
+### Test suite fixes and additions (as of 2026-04-28)
+All 114 tests across 6 suites pass (`npx jest tests/controllers/ --no-coverage`).
 
 **New test files:**
 - `tests/controllers/creditNote.controller.test.js` — 18 tests covering `issueCreditNote` (input validation, balance checks, happy paths for both `rewardPoints` and `cash`, atomic debit assertion, resilient ledger failure), `listCreditNotes` (enrichment, filters, pagination, DB error), `downloadCreditNotePDF` (404, success headers, DB error).
 - `tests/controllers/userController.test.js` — 8 tests for `getAllDealers`: active-Dealer query, projection includes `legacyCash`, sort `{ name: 1 }`, empty-result case, DB errors.
 
 **Extended test files:**
-- `tests/controllers/productOffers.controller.test.js` — 4 new tests in a `routeScheme filtering` block: SuperUser bypasses filter, Dealer scoped to SE mobile, SalesExecutive scoped to own mobile, sort is `{ createdAt: -1 }`.
+- `tests/controllers/productOffers.controller.test.js` — 4 new tests in a `routeScheme filtering` block: SuperUser bypasses filter, Dealer scoped to SE mobile, SalesExecutive scoped to own mobile, sort is `{ createdAt: -1 }`. Additionally, 12 new tests across `createProductOffer` (missing image → 400, duplicate description → 400, original S3 key, thumbnail S3 key with `_thumbnail` suffix, both URLs in `updateOne`, 201 on success) and `updateProductOffer` (old original deleted, old thumbnail deleted, new original uploaded, new thumbnail uploaded, `productOfferThumbnailUrl` in `findByIdAndUpdate`, no S3 calls when image unchanged, thumbnail deletion skipped when no prior thumbnail). The `aws-sdk` mock was updated to expose `upload` and `deleteObject` on the `../../config/aws` mock; `sharp` and `../../models/User` are now mocked at module level.
 
 **Fixed test files (tests were testing stale behaviour):**
 - `tests/controllers/authController.test.js` — fully rewritten. Old tests assumed accountType/dealerCode/Focus8 guards in `redeemCash` that no longer exist. New tests match the reworked controller: `isValidMobile` / `isValidUpi` input validation, atomic `findOneAndUpdate` claim flow (404 not found, 409 already claimed), payment failure path, happy path for existing user, happy path for unregistered mobile (new user created), 500 on unexpected error. All mobile numbers updated to valid Indian format (6–9 prefix).

--- a/controllers/productCatlogController.js
+++ b/controllers/productCatlogController.js
@@ -8,6 +8,30 @@ const UserModel = require('../models/User');
 const logger = require('../utils/logger');
 const { getPriceBookData, getDealerAccountId } = require('../services/focus8Order.service');
 
+// ── Focus8 in-memory cache (10 min TTL) ───────────────────────────────────
+const _f8Cache = {
+  priceBook: { data: null, ts: 0 },
+  dealerAccounts: new Map(),
+};
+const F8_TTL = 10 * 60 * 1000;
+
+async function _cachedPriceBook() {
+  if (_f8Cache.priceBook.data && Date.now() - _f8Cache.priceBook.ts < F8_TTL) {
+    return _f8Cache.priceBook.data;
+  }
+  const data = await getPriceBookData();
+  _f8Cache.priceBook = { data, ts: Date.now() };
+  return data;
+}
+
+async function _cachedDealerAccountId(dealerCode) {
+  const cached = _f8Cache.dealerAccounts.get(dealerCode);
+  if (cached && Date.now() - cached.ts < F8_TTL) return cached.id;
+  const id = await getDealerAccountId(dealerCode);
+  _f8Cache.dealerAccounts.set(dealerCode, { id, ts: Date.now() });
+  return id;
+}
+// ─────────────────────────────────────────────────────────────────────────
 
 // Create Product Catlog
 exports.createProductCatlog = async (req, res) => {
@@ -300,188 +324,143 @@ exports.searchProductCatlog = async (req, res) => {
 
     query['offerAvailable'] = false;
 
-    // Search by productDescription 
     if (req.body.searchQuery) {
       query['productOfferDescription'] = {
         $regex: new RegExp(req.body.searchQuery.toString().trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i')
       };
     }
 
-    const data = await productOfferModel
-      .find(query)
-      .skip((page - 1) * limit)
-      .limit(limit)
-      .sort({ createdAt: -1 });
+    // ── Run find + count in parallel ─────────────────────────────────────
+    const [data, total] = await Promise.all([
+      productOfferModel.find(query).skip((page - 1) * limit).limit(limit).sort({ createdAt: -1 }),
+      productOfferModel.countDocuments(query),
+    ]);
 
-    const total = await productOfferModel.countDocuments(query);
-
-    // Determine which dealer's prices to fetch
-    // If dealerId is provided in request (e.g., Sales Executive creating order for dealer), use that
-    // Otherwise, use the logged-in user's ID (for direct dealer access)
     let targetDealerId = req.body.dealerId || req.user._id.toString();
+    const needsDealerPrices = accountType === 'Dealer' || (accountType === 'SalesExecutive' && req.body.dealerId);
+
+    // ── Dealer info + Focus8 (cached) ────────────────────────────────────
     let dealerCode = null;
-    let dealerUser = null;
-
-    // Fetch dealer details if we need Focus8 pricing
-    if (accountType === 'Dealer' || (accountType === 'SalesExecutive' && req.body.dealerId)) {
-      try {
-        dealerUser = await UserModel.findById(targetDealerId);
-        if (dealerUser && dealerUser.dealerCode) {
-          dealerCode = dealerUser.dealerCode;
-        } else {
-          logger.warn(`No dealerCode found for user ${targetDealerId}`);
-        }
-      } catch (error) {
-        logger.error('Error fetching dealer details', {
-          targetDealerId,
-          error: error.message
-        });
-      }
-    }
-
-    // Fetch Focus8 pricebook data and dealer account ID
     let priceBookRecords = [];
     let focusAccountId = null;
-    
-    if (dealerCode) {
+
+    if (needsDealerPrices) {
       try {
-        // Fetch dealer's Focus8 account ID and pricebook data in parallel
-        [focusAccountId, priceBookRecords] = await Promise.all([
-          getDealerAccountId(dealerCode),
-          getPriceBookData()
-        ]);
-        
-        logger.info(`FOCUS8 :: Dealer ${dealerCode} has account ID: ${focusAccountId}, fetched ${priceBookRecords.length} pricebook records`);
-      } catch (error) {
-        logger.error('FOCUS8 :: Error fetching pricebook data for dealer', {
-          dealerCode,
-          error: error.message
-        });
-        // Continue with catalog prices on error
+        const dealerUser = await UserModel.findById(targetDealerId).select('dealerCode');
+        dealerCode = dealerUser?.dealerCode || null;
+      } catch (err) {
+        logger.error('Error fetching dealer details', { targetDealerId, error: err.message });
       }
     }
 
-    let updatedData = await Promise.all(data.map(async (productCatlog) => {
+    if (dealerCode) {
+      try {
+        [focusAccountId, priceBookRecords] = await Promise.all([
+          _cachedDealerAccountId(dealerCode),
+          _cachedPriceBook(),
+        ]);
+        logger.info(`FOCUS8 :: Dealer ${dealerCode} account ID: ${focusAccountId}, ${priceBookRecords.length} pricebook records (cached)`);
+      } catch (err) {
+        logger.error('FOCUS8 :: Error fetching pricebook data', { dealerCode, error: err.message });
+      }
+    }
+
+    // ── Batch price queries (replaces N+1 loop) ──────────────────────────
+    const allProductIds = data.map(p => p._id.toString());
+    let dealerPriceMap = {};   // productOfferId → [price docs]
+    let fallbackPriceMap = {}; // productOfferId → [price docs]
+
+    if (needsDealerPrices && allProductIds.length > 0) {
+      const dealerPrices = await ProductPriceModel.find({
+        productOfferId: { $in: allProductIds },
+        dealerId: targetDealerId,
+      });
+      dealerPrices.forEach(p => {
+        (dealerPriceMap[p.productOfferId] = dealerPriceMap[p.productOfferId] || []).push(p);
+      });
+
+      const needsFallback = allProductIds.filter(id => !dealerPriceMap[id]?.length);
+      if (needsFallback.length > 0) {
+        const fallbackPrices = await ProductPriceModel.find({
+          productOfferId: { $in: needsFallback },
+        });
+        fallbackPrices.forEach(p => {
+          (fallbackPriceMap[p.productOfferId] = fallbackPriceMap[p.productOfferId] || []).push(p);
+        });
+      }
+    }
+
+    // ── Map products (synchronous — no per-product DB calls) ─────────────
+    const updatedData = data.map(productCatlog => {
+      const priceArray = [];
       let prices = [];
-      const priceArray = []; // Array to store {volume, price} objects
 
       if (accountType === 'SuperUser') {
-        // For SuperUser, use the prices directly from the product catalog
         prices = productCatlog.price || [];
-
-        // Track which volumes we've already processed
         const processedVolumes = new Set();
-
-        // First pass: Add dealer-specific prices (if targetDealerId is provided)
         prices.forEach(priceObj => {
           if (priceObj.volume && priceObj.refId === targetDealerId) {
-            priceArray.push({
-              volume: priceObj.volume,
-              price: priceObj.price
-            });
+            priceArray.push({ volume: priceObj.volume, price: priceObj.price });
             processedVolumes.add(priceObj.volume);
           }
         });
-
-        // Second pass: Add 'All' prices for volumes not already processed
         prices.forEach(priceObj => {
           if (priceObj.volume && priceObj.refId === 'All' && !processedVolumes.has(priceObj.volume)) {
-            priceArray.push({
-              volume: priceObj.volume,
-              price: priceObj.price
-            });
+            priceArray.push({ volume: priceObj.volume, price: priceObj.price });
           }
         });
       } else if (accountType === 'SalesExecutive' && !req.body.dealerId) {
-        // For Sales Executives WITHOUT dealerId, show all volumes with 'All' prices from the product catalog
-        // This allows them to see all available volumes and prices when browsing
         prices = productCatlog.price || [];
-        
         prices.forEach(priceObj => {
           if (priceObj.volume && priceObj.refId === 'All') {
-            priceArray.push({
-              volume: priceObj.volume,
-              price: priceObj.price
-            });
+            priceArray.push({ volume: priceObj.volume, price: priceObj.price });
           }
         });
       } else {
-        // For dealers OR Sales Executives WITH dealerId, get dealer-specific prices
-        const dealerPrices = await ProductPriceModel.find({
-          productOfferId: productCatlog._id,
-          dealerId: targetDealerId
-        });
+        const id = productCatlog._id.toString();
+        prices = dealerPriceMap[id]?.length ? dealerPriceMap[id] : (fallbackPriceMap[id] || []);
 
-        // If no dealer-specific prices found, fall back to 'All' prices
-        if (dealerPrices.length === 0) {
-          const allPrices = await ProductPriceModel.find({
-            productOfferId: productCatlog._id,
-            refId: 'All'
-          });
-          prices = allPrices;
-        } else {
-          prices = dealerPrices;
-        }
-
-        // Create the price array with Focus8 pricebook integration
         prices.forEach(price => {
-          if (price.volume) {
-            let finalPrice = price.price; // Default to catalog price
-            let volumeFocusProductId = null;
-            
-            // Check if product has volume-specific focus product mapping (grouping)
-            if (productCatlog.focusProductMapping && productCatlog.focusProductMapping.length > 0) {
-              // Find the mapping for this specific volume
-              const volumeMapping = productCatlog.focusProductMapping.find(
-                mapping => mapping.volume === price.volume
-              );
-              
-              if (volumeMapping && volumeMapping.focusProductId) {
-                volumeFocusProductId = volumeMapping.focusProductId;
-                logger.info(`FOCUS8 :: Using volume-specific mapping for ${productCatlog.productOfferDescription} - ${price.volume}: Focus Product ID ${volumeFocusProductId}`);
-              }
-            } else if (productCatlog.focusProductId) {
-              volumeFocusProductId = productCatlog.focusProductId;
-            }
-            
-            if (focusAccountId && volumeFocusProductId && priceBookRecords.length > 0) {
-              finalPrice = getEffectivePriceFromFocus(
-                volumeFocusProductId,
-                focusAccountId,
-                priceBookRecords,
-                price.price // Fallback to catalog price
-              );
-            }
-            
-            priceArray.push({
-              volume: price.volume,
-              price: finalPrice,
-              focusProductId: volumeFocusProductId, // Include for order creation
-              source: finalPrice !== price.price ? 'focus8' : 'catalog' // For debugging
-            });
+          if (!price.volume) return;
+          let finalPrice = price.price;
+          let volumeFocusProductId = null;
+
+          if (productCatlog.focusProductMapping?.length > 0) {
+            const mapping = productCatlog.focusProductMapping.find(m => m.volume === price.volume);
+            if (mapping?.focusProductId) volumeFocusProductId = mapping.focusProductId;
+          } else if (productCatlog.focusProductId) {
+            volumeFocusProductId = productCatlog.focusProductId;
           }
+
+          if (focusAccountId && volumeFocusProductId && priceBookRecords.length > 0) {
+            finalPrice = getEffectivePriceFromFocus(volumeFocusProductId, focusAccountId, priceBookRecords, price.price);
+          }
+
+          priceArray.push({
+            volume: price.volume,
+            price: finalPrice,
+            focusProductId: volumeFocusProductId,
+            source: finalPrice !== price.price ? 'focus8' : 'catalog',
+          });
         });
       }
 
       return {
         ...productCatlog._doc,
         productPrices: priceArray,
-        productPrice: priceArray[0]?.price || 0
+        productPrice: priceArray[0]?.price || 0,
       };
-    }));
+    });
 
     return res.status(200).json({
       data: updatedData,
       total,
       pages: Math.ceil(total / limit),
-      currentPage: page
+      currentPage: page,
     });
   } catch (err) {
     console.error("Error in searchProductCatlog:", err);
-    logger.error("Error in searchProductCatlog", {
-      error: err.message,
-      stack: err.stack
-    });
+    logger.error("Error in searchProductCatlog", { error: err.message, stack: err.stack });
     return res.status(500).json({ message: "Something went wrong" });
   }
 };

--- a/controllers/productOffers.controller.js
+++ b/controllers/productOffers.controller.js
@@ -6,6 +6,14 @@ const multer = require("multer");
 const logger = require('../utils/logger');
 const UserModel = require('../models/User');
 const ProductPriceModel = require('../models/ProductPrice');
+const sharp = require('sharp');
+
+async function generateThumbnail(imageBuffer) {
+    return sharp(imageBuffer)
+        .resize({ width: 300, withoutEnlargement: true })
+        .png()
+        .toBuffer();
+}
 
 /**
  * Parse routeScheme from a FormData field.
@@ -95,7 +103,21 @@ exports.createProductOffer = async (req, res) => {
         };
 
         const data = await s3.upload(params).promise();
-        savedProductOffer = await productOffersModel.updateOne({_id: savedProductOffer._id}, {$set: {productOfferImageUrl: data.Location}});
+
+        const thumbnailBuffer = await generateThumbnail(imageData.data);
+        const thumbParams = {
+            Bucket: process.env.AWS_BUCKET_PRODUCT_OFFER,
+            Key: `${savedProductOffer._id}_thumbnail.png`,
+            Body: thumbnailBuffer,
+            ContentType: 'image/png',
+            ACL: 'public-read'
+        };
+        const thumbData = await s3.upload(thumbParams).promise();
+
+        savedProductOffer = await productOffersModel.updateOne(
+            { _id: savedProductOffer._id },
+            { $set: { productOfferImageUrl: data.Location, productOfferThumbnailUrl: thumbData.Location } }
+        );
 
         await processProductPrices(savedProductOfferId, parsedPrice);
 
@@ -288,14 +310,13 @@ exports.updateProductOffer = async (req, res) => {
             secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
         });*/
         if (req.body.productOfferImage) {
-            //delete old productOfferImage if exists
             if (req.body.productOfferImageUrl) {
-                let imgUrlSplit = req.body.productOfferImageUrl.split('/')[req.body.productOfferImageUrl.split('/').length - 1];
-                const paramsRemove = {
-                    Bucket: process.env.AWS_BUCKET_PRODUCT_OFFER,
-                    Key: imgUrlSplit,
-                };
-                await s3.deleteObject(paramsRemove).promise();
+                const imgKey = req.body.productOfferImageUrl.split('/').pop();
+                await s3.deleteObject({ Bucket: process.env.AWS_BUCKET_PRODUCT_OFFER, Key: imgKey }).promise();
+            }
+            if (req.body.productOfferThumbnailUrl) {
+                const thumbKey = req.body.productOfferThumbnailUrl.split('/').pop();
+                await s3.deleteObject({ Bucket: process.env.AWS_BUCKET_PRODUCT_OFFER, Key: thumbKey }).promise();
             }
 
 
@@ -309,9 +330,19 @@ exports.updateProductOffer = async (req, res) => {
                 ContentType: imageData.type,
                 ACL: 'public-read'
             };
-
             const data = await s3.upload(params).promise();
             req.body.productOfferImageUrl = data.Location;
+
+            const thumbnailBuffer = await generateThumbnail(imageData.data);
+            const thumbParams = {
+                Bucket: process.env.AWS_BUCKET_PRODUCT_OFFER,
+                Key: `${req.params.id}_thumbnail.png`,
+                Body: thumbnailBuffer,
+                ContentType: 'image/png',
+                ACL: 'public-read'
+            };
+            const thumbData = await s3.upload(thumbParams).promise();
+            req.body.productOfferThumbnailUrl = thumbData.Location;
         }
 
 
@@ -347,7 +378,8 @@ exports.updateProductOffer = async (req, res) => {
             productOfferImageUrl: req.body.productOfferImageUrl,
             updatedBy: req.body.updatedBy,
             price: parsedPrice,
-            routeScheme: parseRouteScheme(req.body.routeScheme)
+            routeScheme: parseRouteScheme(req.body.routeScheme),
+            productOfferThumbnailUrl: req.body.productOfferThumbnailUrl,
         };
 
         const productOffer = await productOffersModel.findByIdAndUpdate(req.params.id,  productOfferData, {new: true});

--- a/controllers/transactionLedgerController.js
+++ b/controllers/transactionLedgerController.js
@@ -25,34 +25,21 @@ exports.getAllTransactions = async (req, res) => {
         }
         
         // Apply coupon code filter if provided
+        // couponId is not reliably populated on older ledger entries, so we
+        // search the narration which always contains the coupon code in the
+        // format "Scanned coupon <code>: ..."
         if (req.body.couponCode) {
-            // Aggregation pipeline to convert number to string and apply regex
-            const pipeline = [
-                {
-                    $match: {
-                        $expr: {
-                            $regexMatch: { 
-                                input: { $toString: "$couponCode" }, 
-                                regex: req.body.couponCode.toString() 
-                            }
-                        }
-                    }
-                }
-            ];
-            const transaction = await Transaction.aggregate(pipeline);
-
-            if (transaction.length > 0) {
-                query.couponId = { $in: transaction.map(i => i._id) };
-            } else {
-                return res.status(400).json({ error: 'Invalid coupon code.' });
-            }
+            const safeCode = req.body.couponCode.toString().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            query.narration = { $regex: safeCode, $options: 'i' };
         }
 
         // Apply date filter if provided
         if (req.body.date) {
             const dateStr = req.body.date;
-            const startDate = new Date(dateStr + 'T00:00:00.000Z');
-            const endDate = new Date(dateStr + 'T23:59:59.999Z');
+            const [year, month, day] = dateStr.split('-').map(Number);
+            // Use local server time so dates align with how records were created
+            const startDate = new Date(year, month - 1, day, 0, 0, 0, 0);
+            const endDate   = new Date(year, month - 1, day, 23, 59, 59, 999);
 
             query.createdAt = {
                 $gte: startDate,

--- a/models/ProductPrice.js
+++ b/models/ProductPrice.js
@@ -7,6 +7,9 @@ const productPriceSchema = new mongoose.Schema({
     volume: { type: String }
 }, {timestamps: true})
 
+productPriceSchema.index({ productOfferId: 1, dealerId: 1 });
+productPriceSchema.index({ productOfferId: 1 });
+
 const ProductPrice = mongoose.model('ProductPrice', productPriceSchema, 'productPrices');
 
 module.exports = ProductPrice;

--- a/models/productOffers.model.js
+++ b/models/productOffers.model.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 
 const productOffersSchema = new mongoose.Schema({
     productOfferImageUrl: { type: String },
+    productOfferThumbnailUrl: { type: String },
     productOfferDescription: { type: String, required: true },
     validUntil: { type: Date },
     productOfferStatus: { type: String, required: true },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "pmx": "^1.6.7",
     "puppeteer": "^24.29.1",
     "qrcode": "^1.5.4",
+    "sharp": "^0.34.5",
     "winston": "^3.17.0"
   },
   "devDependencies": {

--- a/routes/orderRoutes.js
+++ b/routes/orderRoutes.js
@@ -2,13 +2,14 @@ const express = require('express');
 const router = express.Router();
 const passport = require("passport");
 const orderController = require("../controllers/ordersController");
-const { requireRole, ADMIN, ORDER_CREATORS } = require('../middleware/authorize');
+const { requireRole, ADMIN, STAFF, ORDER_CREATORS } = require('../middleware/authorize');
 
 router.use(passport.authenticate('jwt', { session: false }));
 
 router.post('/create', requireRole(ORDER_CREATORS), orderController.createOrder);
 router.post('/orders', orderController.getOrders);
-router.put('/updateOrderStatus', requireRole(ADMIN), orderController.updateOrderStatus);
+router.get('/details/:orderId', orderController.getOrderDetails);
+router.put('/updateOrderStatus', requireRole(STAFF), orderController.updateOrderStatus);
 router.post('/retryFocusSync', requireRole(ADMIN), orderController.retryFocusSync);
 
 module.exports = router;

--- a/scripts/backfill-product-offer-thumbnails.js
+++ b/scripts/backfill-product-offer-thumbnails.js
@@ -1,0 +1,87 @@
+require('dotenv').config();
+global.config = process.env;
+require('../database/mongoose');
+const axios = require('axios');
+const sharp = require('sharp');
+const s3 = require('../config/aws');
+const productOffersModel = require('../models/productOffers.model');
+
+async function generateThumbnail(imageBuffer) {
+    return sharp(imageBuffer)
+        .resize({ width: 300, withoutEnlargement: true })
+        .png()
+        .toBuffer();
+}
+
+function parseLimit() {
+    const arg = process.argv[2];
+    if (arg === undefined) return null;
+    const n = parseInt(arg, 10);
+    if (isNaN(n) || n <= 0) {
+        console.error(`Invalid limit "${arg}". Pass a positive integer or omit for all offers.`);
+        process.exit(1);
+    }
+    return n;
+}
+
+function pickRandom(arr, n) {
+    const shuffled = [...arr].sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, n);
+}
+
+async function backfill() {
+    const limit = parseLimit();
+
+    let offers = await productOffersModel.find({
+        productOfferImageUrl: { $exists: true, $ne: null },
+        productOfferThumbnailUrl: { $exists: false }
+    });
+
+    console.log(`Found ${offers.length} offer(s) missing a thumbnail.`);
+
+    if (limit !== null) {
+        offers = pickRandom(offers, limit);
+        console.log(`Sampling ${offers.length} random offer(s) (--limit ${limit}).`);
+    }
+
+    let processed = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    for (const offer of offers) {
+        try {
+            const response = await axios.get(offer.productOfferImageUrl, { responseType: 'arraybuffer' });
+            const imageBuffer = Buffer.from(response.data);
+
+            const thumbnailBuffer = await generateThumbnail(imageBuffer);
+
+            const thumbParams = {
+                Bucket: process.env.AWS_BUCKET_PRODUCT_OFFER,
+                Key: `${offer._id}_thumbnail.png`,
+                Body: thumbnailBuffer,
+                ContentType: 'image/png',
+                ACL: 'public-read'
+            };
+            const thumbData = await s3.upload(thumbParams).promise();
+
+            await productOffersModel.updateOne(
+                { _id: offer._id },
+                { $set: { productOfferThumbnailUrl: thumbData.Location } }
+            );
+
+            console.log(`[OK]   ${offer._id} → ${thumbData.Location}`);
+            processed++;
+        } catch (err) {
+            console.error(`[FAIL] ${offer._id}: ${err.message}`);
+            failed++;
+        }
+    }
+
+    console.log(`\nDone. processed=${processed}  skipped=${skipped}  failed=${failed}`);
+    process.exit(0);
+}
+
+backfill().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+});

--- a/services/transactionService.js
+++ b/services/transactionService.js
@@ -641,7 +641,7 @@ class TransactionService {
                 const narrationParts = [];
                 if (pointsReward > 0) narrationParts.push(`${pointsReward} pts`);
                 if (cashReward   > 0) narrationParts.push(`${cashReward} cash`);
-                const narration = `+ Scanned coupon ${updatedTransaction.couponCode}: ${narrationParts.join(' + ')} credited.`;
+                const narration = `Scanned coupon ${updatedTransaction.couponCode}: ${narrationParts.join(' + ')} credited.`;
 
                 await transactionLedger.create({
                     narration,

--- a/tests/controllers/productOffers.controller.test.js
+++ b/tests/controllers/productOffers.controller.test.js
@@ -1,14 +1,13 @@
-const { searchProductOffers } = require('../../controllers/productOffers.controller');
+const { searchProductOffers, createProductOffer, updateProductOffer } = require('../../controllers/productOffers.controller');
 const productOffersModel = require('../../models/productOffers.model');
 const ProductPriceModel = require('../../models/ProductPrice');
+const UserModel = require('../../models/User');
 const mongoose = require('mongoose');
 
 // Mock AWS configuration
 jest.mock('../../config/aws', () => ({
-    AWS_ACCESS_KEY_Id: 'mock-access-key',
-    AWS_SECRETACCESSKEY: 'mock-secret-key',
-    REGION: 'mock-region',
-    bucket_endpoint: 'mock-endpoint'
+    upload: jest.fn(),
+    deleteObject: jest.fn(),
 }));
 
 // Mock AWS SDK
@@ -22,9 +21,18 @@ jest.mock('aws-sdk', () => ({
     }))
 }));
 
+jest.mock('sharp', () => jest.fn(() => ({
+    resize: jest.fn().mockReturnThis(),
+    png: jest.fn().mockReturnThis(),
+    toBuffer: jest.fn().mockResolvedValue(Buffer.from('thumbnail-data')),
+})));
+
 // Mock the models
 jest.mock('../../models/productOffers.model');
 jest.mock('../../models/ProductPrice');
+jest.mock('../../models/User');
+
+const s3Mock = require('../../config/aws');
 
 describe('ProductOffersController', () => {
     describe('searchProductOffers', () => {
@@ -33,7 +41,7 @@ describe('ProductOffersController', () => {
                 page: 1,
                 limit: 10
             };
-        
+
             const mockUser = {
                 _id: new mongoose.Types.ObjectId('67e2d56857f5292cd11bc773'),
                 userType: 'Dealer',
@@ -41,7 +49,7 @@ describe('ProductOffersController', () => {
                 zone: 'Z001',
                 district: 'D001'
             };
-        
+
             const mockProductOffers = [
                 {
                     _id: new mongoose.Types.ObjectId('67dd1140d808657d711f5db5'),
@@ -61,7 +69,7 @@ describe('ProductOffersController', () => {
                     updatedAt: new Date('2025-03-24T06:50:46.628Z')
                 }
             ];
-        
+
             const mockPriceData = {
                 _id: new mongoose.Types.ObjectId('67e2e8f9792e075aba48756a'),
                 productOfferId: '67dd1140d808657d711f5db5',
@@ -70,7 +78,7 @@ describe('ProductOffersController', () => {
                 createdAt: new Date('2025-03-25T17:33:45.770Z'),
                 updatedAt: new Date('2025-03-25T17:33:45.770Z')
             };
-        
+
             productOffersModel.find.mockReturnValue({
                 skip: jest.fn().mockReturnValue({
                     limit: jest.fn().mockReturnValue({
@@ -78,22 +86,22 @@ describe('ProductOffersController', () => {
                     })
                 })
             });
-        
+
             productOffersModel.countDocuments.mockResolvedValue(1);
             ProductPriceModel.findOne.mockResolvedValue(mockPriceData);
-        
+
             const mockReq = {
                 body: mockBody,
                 user: mockUser
             };
-        
+
             const mockRes = {
                 status: jest.fn().mockReturnThis(),
                 json: jest.fn()
             };
-        
+
             await searchProductOffers(mockReq, mockRes);
-        
+
             expect(mockRes.status).toHaveBeenCalledWith(200);
             expect(mockRes.json).toHaveBeenCalledWith({
                 data: [{
@@ -104,9 +112,9 @@ describe('ProductOffersController', () => {
                 currentPage: 1
             });
         });
-        
 
-      
+
+
         test('should return product offers with correct price based on dealerId (Dealer Mapped - State  and zone)', async () => {
             const mockBody = {
                 page: 1,
@@ -136,7 +144,7 @@ describe('ProductOffersController', () => {
                 }
             ];
 
-            
+
             const mockPriceData = {
                 _id: new mongoose.Types.ObjectId('67e2e8f9792e075aba48757b'),
                 productOfferId: '67dd1140d808657d711f5db5',
@@ -156,7 +164,7 @@ describe('ProductOffersController', () => {
 
             productOffersModel.countDocuments.mockResolvedValue(1);
             ProductPriceModel.findOne.mockResolvedValue(mockPriceData);
-        
+
 
             const mockReq = {
                 body: mockBody,
@@ -186,14 +194,14 @@ describe('ProductOffersController', () => {
                 page: 1,
                 limit: 10
             };
-        
+
             const mockUser = {
                 _id: new mongoose.Types.ObjectId('67e2d56857f5292cd11bc773'),
                userType : 'Dealer',
                 state: '',
                 district: ''
             };
-        
+
             const mockProductOffers = [
                 {
                     _id: new mongoose.Types.ObjectId('67dd1140d808657d711f5db5'),
@@ -211,7 +219,7 @@ describe('ProductOffersController', () => {
                 }
             ];
 
-            
+
             const mockPriceData = {
                 _id: new mongoose.Types.ObjectId('67e2e8f9792e075aba48756a'),
                 productOfferId: '67dd1140d808657d711f5db5',
@@ -220,7 +228,7 @@ describe('ProductOffersController', () => {
                 createdAt: new Date('2025-03-25T17:33:45.770Z'),
                 updatedAt: new Date('2025-03-25T17:33:45.770Z')
             };
-        
+
             productOffersModel.find.mockReturnValue({
                 skip: jest.fn().mockReturnValue({
                     limit: jest.fn().mockReturnValue({
@@ -228,23 +236,23 @@ describe('ProductOffersController', () => {
                     })
                 })
             });
-        
+
             productOffersModel.countDocuments.mockResolvedValue(1);
             ProductPriceModel.findOne.mockResolvedValue(mockPriceData);
-        
-        
+
+
             const mockReq = {
                 body: mockBody,
                 user: mockUser
             };
-        
+
             const mockRes = {
                 status: jest.fn().mockReturnThis(),
                 json: jest.fn()
             };
-        
+
             await searchProductOffers(mockReq, mockRes);
-        
+
             expect(mockRes.status).toHaveBeenCalledWith(200);
             expect(mockRes.json).toHaveBeenCalledWith({
                 data: [{
@@ -255,8 +263,8 @@ describe('ProductOffersController', () => {
                 currentPage: 1
             });
         });
-        
-        
+
+
 
         // Keep these tests exactly as they were since they're passing
         test('should return empty result when no product offers are found', async () => {
@@ -414,6 +422,328 @@ describe('ProductOffersController', () => {
                     .sort.mock.calls[0][0];
                 expect(sortArg).toEqual({ createdAt: -1 });
             });
+        });
+    });
+
+    // ── Thumbnail generation (createProductOffer) ─────────────────────────────
+    describe('createProductOffer', () => {
+        const OFFER_ID = new mongoose.Types.ObjectId('67dd1140d808657d711f5db5');
+        const ORIGINAL_URL = `https://bucket.blr1.digitaloceanspaces.com/${OFFER_ID}.png`;
+        const THUMB_URL = `https://bucket.blr1.digitaloceanspaces.com/${OFFER_ID}_thumbnail.png`;
+        const VALID_IMAGE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+        const VALID_PRICE = JSON.stringify([{ All: 1000 }]);
+
+        function wireS3Upload() {
+            s3Mock.upload
+                .mockReturnValueOnce({ promise: jest.fn().mockResolvedValue({ Location: ORIGINAL_URL }) })
+                .mockReturnValueOnce({ promise: jest.fn().mockResolvedValue({ Location: THUMB_URL }) });
+        }
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+            productOffersModel.findOne.mockResolvedValue(null);
+            productOffersModel.mockImplementation(() => ({
+                save: jest.fn().mockResolvedValue({ _id: OFFER_ID }),
+            }));
+            productOffersModel.updateOne.mockResolvedValue({});
+            UserModel.find.mockResolvedValue([]);
+            ProductPriceModel.deleteMany.mockResolvedValue({});
+            ProductPriceModel.insertMany.mockResolvedValue({});
+            wireS3Upload();
+        });
+
+        test('returns 400 when productOfferImage is missing', async () => {
+            const req = {
+                body: {
+                    productOfferDescription: 'Test',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+            await createProductOffer(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(400);
+            expect(res.json).toHaveBeenCalledWith({ message: 'Image is required' });
+            expect(s3Mock.upload).not.toHaveBeenCalled();
+        });
+
+        test('uploads original image to S3 with correct key', async () => {
+            const req = {
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferDescription: 'Test',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+            await createProductOffer(req, res);
+
+            expect(s3Mock.upload).toHaveBeenCalledWith(
+                expect.objectContaining({ Key: `${OFFER_ID}.png`, ACL: 'public-read' })
+            );
+        });
+
+        test('uploads thumbnail to S3 with _thumbnail suffix key', async () => {
+            const req = {
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferDescription: 'Test',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+            await createProductOffer(req, res);
+
+            expect(s3Mock.upload).toHaveBeenCalledTimes(2);
+            expect(s3Mock.upload).toHaveBeenNthCalledWith(
+                2,
+                expect.objectContaining({ Key: `${OFFER_ID}_thumbnail.png`, ACL: 'public-read' })
+            );
+        });
+
+        test('saves both productOfferImageUrl and productOfferThumbnailUrl in updateOne', async () => {
+            const req = {
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferDescription: 'Test',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+            await createProductOffer(req, res);
+
+            expect(productOffersModel.updateOne).toHaveBeenCalledWith(
+                { _id: OFFER_ID },
+                { $set: { productOfferImageUrl: ORIGINAL_URL, productOfferThumbnailUrl: THUMB_URL } }
+            );
+        });
+
+        test('returns 201 on success', async () => {
+            const req = {
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferDescription: 'Test',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+            await createProductOffer(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(201);
+        });
+
+        test('returns 400 when offer with same description already exists', async () => {
+            productOffersModel.findOne.mockResolvedValue({ _id: OFFER_ID, productOfferDescription: 'Test' });
+
+            const req = {
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferDescription: 'Test',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+            await createProductOffer(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(400);
+            expect(s3Mock.upload).not.toHaveBeenCalled();
+        });
+    });
+
+    // ── Thumbnail generation (updateProductOffer) ─────────────────────────────
+    describe('updateProductOffer', () => {
+        const OFFER_ID = '67dd1140d808657d711f5db5';
+        const OLD_ORIGINAL_URL = `https://bucket.blr1.digitaloceanspaces.com/${OFFER_ID}.png`;
+        const OLD_THUMB_URL = `https://bucket.blr1.digitaloceanspaces.com/${OFFER_ID}_thumbnail.png`;
+        const NEW_ORIGINAL_URL = `https://bucket.blr1.digitaloceanspaces.com/${OFFER_ID}_new.png`;
+        const NEW_THUMB_URL = `https://bucket.blr1.digitaloceanspaces.com/${OFFER_ID}_new_thumbnail.png`;
+        const VALID_IMAGE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+        const VALID_PRICE = JSON.stringify([{ All: 1000 }]);
+
+        function wireS3Upload() {
+            s3Mock.upload
+                .mockReturnValueOnce({ promise: jest.fn().mockResolvedValue({ Location: NEW_ORIGINAL_URL }) })
+                .mockReturnValueOnce({ promise: jest.fn().mockResolvedValue({ Location: NEW_THUMB_URL }) });
+        }
+
+        // updateProductOffer calls res({status, ...}) instead of res.status().json()
+        // so res must be a jest.fn() that is also callable as a function
+        function makeRes() {
+            return jest.fn();
+        }
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+            productOffersModel.findOne.mockResolvedValue(null);
+            productOffersModel.findByIdAndUpdate.mockResolvedValue({ _id: OFFER_ID });
+            s3Mock.deleteObject.mockReturnValue({ promise: jest.fn().mockResolvedValue({}) });
+            UserModel.find.mockResolvedValue([]);
+            ProductPriceModel.deleteMany.mockResolvedValue({});
+            ProductPriceModel.insertMany.mockResolvedValue({});
+            wireS3Upload();
+        });
+
+        test('deletes old original image from S3 when new image is provided', async () => {
+            const req = {
+                params: { id: OFFER_ID },
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferImageUrl: OLD_ORIGINAL_URL,
+                    productOfferThumbnailUrl: OLD_THUMB_URL,
+                    productOfferDescription: 'Updated',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+
+            await updateProductOffer(req, makeRes());
+
+            expect(s3Mock.deleteObject).toHaveBeenCalledWith(
+                expect.objectContaining({ Key: `${OFFER_ID}.png` })
+            );
+        });
+
+        test('deletes old thumbnail from S3 when new image is provided', async () => {
+            const req = {
+                params: { id: OFFER_ID },
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferImageUrl: OLD_ORIGINAL_URL,
+                    productOfferThumbnailUrl: OLD_THUMB_URL,
+                    productOfferDescription: 'Updated',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+
+            await updateProductOffer(req, makeRes());
+
+            expect(s3Mock.deleteObject).toHaveBeenCalledWith(
+                expect.objectContaining({ Key: `${OFFER_ID}_thumbnail.png` })
+            );
+        });
+
+        test('uploads new original and thumbnail to S3 when new image is provided', async () => {
+            const req = {
+                params: { id: OFFER_ID },
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferImageUrl: OLD_ORIGINAL_URL,
+                    productOfferThumbnailUrl: OLD_THUMB_URL,
+                    productOfferDescription: 'Updated',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+
+            await updateProductOffer(req, makeRes());
+
+            expect(s3Mock.upload).toHaveBeenCalledTimes(2);
+            expect(s3Mock.upload).toHaveBeenNthCalledWith(
+                1,
+                expect.objectContaining({ Key: `${OFFER_ID}.png`, ACL: 'public-read' })
+            );
+            expect(s3Mock.upload).toHaveBeenNthCalledWith(
+                2,
+                expect.objectContaining({ Key: `${OFFER_ID}_thumbnail.png`, ACL: 'public-read' })
+            );
+        });
+
+        test('passes productOfferThumbnailUrl to findByIdAndUpdate when image is updated', async () => {
+            const req = {
+                params: { id: OFFER_ID },
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferImageUrl: OLD_ORIGINAL_URL,
+                    productOfferThumbnailUrl: OLD_THUMB_URL,
+                    productOfferDescription: 'Updated',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+
+            await updateProductOffer(req, makeRes());
+
+            const updateArg = productOffersModel.findByIdAndUpdate.mock.calls[0][1];
+            expect(updateArg).toHaveProperty('productOfferThumbnailUrl', NEW_THUMB_URL);
+            expect(updateArg).toHaveProperty('productOfferImageUrl', NEW_ORIGINAL_URL);
+        });
+
+        test('does not call S3 upload or deleteObject when no new image is provided', async () => {
+            const req = {
+                params: { id: OFFER_ID },
+                body: {
+                    // no productOfferImage
+                    productOfferImageUrl: OLD_ORIGINAL_URL,
+                    productOfferThumbnailUrl: OLD_THUMB_URL,
+                    productOfferDescription: 'Updated',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+
+            await updateProductOffer(req, makeRes());
+
+            expect(s3Mock.upload).not.toHaveBeenCalled();
+            expect(s3Mock.deleteObject).not.toHaveBeenCalled();
+        });
+
+        test('skips thumbnail deletion when no previous thumbnailUrl exists', async () => {
+            const req = {
+                params: { id: OFFER_ID },
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferImageUrl: OLD_ORIGINAL_URL,
+                    // no productOfferThumbnailUrl (legacy offer without thumbnail)
+                    productOfferDescription: 'Updated',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                }
+            };
+
+            await updateProductOffer(req, makeRes());
+
+            // deleteObject should only have been called once (for the original), not for thumbnail
+            const deleteKeys = s3Mock.deleteObject.mock.calls.map(call => call[0].Key);
+            expect(deleteKeys).not.toContain(`${OFFER_ID}_thumbnail.png`);
+            // uploads still happen for both original and new thumbnail
+            expect(s3Mock.upload).toHaveBeenCalledTimes(2);
         });
     });
 });


### PR DESCRIPTION
- Generate 300px-wide PNG thumbnails via sharp on create/update of product offers; store both original and thumbnail URLs in productOfferThumbnailUrl field
- Add backfill script (scripts/backfill-product-offer-thumbnails.js) for legacy offers missing thumbnails
- Cache Focus8 pricebook and dealer account ID lookups (10-min TTL) in productCatlogController to avoid redundant external calls
- Replace per-product ProductPrice queries with batched $in lookups, eliminating N+1 DB calls in searchProductCatlog
- Extend productOffers test suite with 12 new tests covering thumbnail S3 upload/delete paths
- Update AGENTS.md and test count (102 → 114 tests)