### PR TITLE
feat: painter QR redemption — points only, authorized via parentDeale…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,9 @@ The QR-scan redemption (`POST /transaction/redeemPoints`, handler in `services/t
   - `cashReward`     — cash credited on this row
   - `cashBalance`    — `User.cash` after this row's effect
   Readers should treat any undefined pair as "this row did not affect that track". Old rows pre-dating the rename were migrated to the new field names by `mongoscripts/rename_ledger_points_fields.js` (run before deploying the renamed code); old rows do not carry the cash fields.
-- **Eligibility** is unchanged: only `accountType` ∈ `POINTS_REDEEM_ELIGIBLE_ACCOUNT_TYPES` (env-driven, defaults to `Dealer`) with a `dealerCode` that resolves in Focus8 may redeem.
+- **Eligibility**: `accountType` must be in `POINTS_REDEEM_ELIGIBLE_ACCOUNT_TYPES` (env-driven, defaults to `Dealer`; production `.env` includes `Painter`). Behaviour differs by type:
+  - **Dealer** — must have a `dealerCode` that resolves in Focus8. Redeems **both** points and cash tracks.
+  - **Painter** — must have a `parentDealerCode` that resolves in Focus8 (authorization via their parent dealer). Redeems **points track only**; cash track is never touched.
 
 When extending this flow, preserve the per-track shape: introduce a new track with its own `*RedeemedBy/At` pair on the coupon, its own balance field on the User, and add it to the same `if (allTracksRedeemed) → 404` guard rather than reusing one of the existing tracks.
 

--- a/services/transactionService.js
+++ b/services/transactionService.js
@@ -517,16 +517,31 @@ class TransactionService {
     };
 
     async redeemCouponPoints(req, res) {
-        // Only Dealers present in both our DB and Focus8 are eligible to redeem points
+        // Dealers redeem both points and cash; Painters redeem points only.
         if (!redeemEligibleAccountTypes.includes(req.user.accountType)) {
             return res.status(403).json({ message: `Only ${redeemEligibleAccountTypes.join(', ')} are eligible to redeem points.` });
         }
-        if (!req.user.dealerCode) {
-            return res.status(403).json({ message: 'Dealer code not set. Contact support.' });
-        }
-        const focusAccountId = await getDealerAccountId(req.user.dealerCode);
-        if (!focusAccountId) {
-            return res.status(403).json({ message: 'Dealer not found in Focus8. Contact support.' });
+
+        const isPainter = req.user.accountType === 'Painter';
+
+        if (isPainter) {
+            // Painters are authorized via their parent dealer's Focus8 account
+            if (!req.user.parentDealerCode) {
+                return res.status(403).json({ message: 'Parent dealer code not set. Contact support.' });
+            }
+            const focusAccountId = await getDealerAccountId(req.user.parentDealerCode);
+            if (!focusAccountId) {
+                return res.status(403).json({ message: 'Parent dealer not found in Focus8. Contact support.' });
+            }
+        } else {
+            // Dealers must be directly registered in Focus8
+            if (!req.user.dealerCode) {
+                return res.status(403).json({ message: 'Dealer code not set. Contact support.' });
+            }
+            const focusAccountId = await getDealerAccountId(req.user.dealerCode);
+            if (!focusAccountId) {
+                return res.status(403).json({ message: 'Dealer not found in Focus8. Contact support.' });
+            }
         }
 
         const { qrCodeUrl } = req.body;  // Assuming qr is passed as a URL parameter
@@ -562,9 +577,16 @@ class TransactionService {
             const pointsAlreadyRedeemed = document.pointsRedeemedBy !== undefined;
             const cashAlreadyRedeemed   = document.cashRedeemedBy   !== undefined;
 
-            if (pointsAlreadyRedeemed && cashAlreadyRedeemed) {
-                logger.warn('Coupon fully redeemed already (both points and cash tracks used)', {
+            // Painters only get the points track, so the coupon is exhausted for them
+            // as soon as points are taken. Dealers need both tracks used.
+            const allTracksRedeemed = isPainter
+                ? pointsAlreadyRedeemed
+                : (pointsAlreadyRedeemed && cashAlreadyRedeemed);
+
+            if (allTracksRedeemed) {
+                logger.warn('Coupon already redeemed', {
                     couponCode: document.couponCode,
+                    isPainter,
                     pointsRedeemedBy: document.pointsRedeemedBy,
                     cashRedeemedBy: document.cashRedeemedBy,
                 });
@@ -580,7 +602,8 @@ class TransactionService {
                 updateSet.pointsRedeemedBy = req.user.mobile;
                 updateSet.pointsRedeemedAt = now;
             }
-            if (!cashAlreadyRedeemed) {
+            // Painters never redeem cash
+            if (!isPainter && !cashAlreadyRedeemed) {
                 updateSet.cashRedeemedBy = req.user.mobile;
                 updateSet.cashRedeemedAt = now;
             }
@@ -593,7 +616,7 @@ class TransactionService {
             logger.info('Successfully updated coupon — redeemed tracks', {
                 couponCode: updatedTransaction && updatedTransaction.couponCode,
                 pointsRedeemedNow: !pointsAlreadyRedeemed,
-                cashRedeemedNow: !cashAlreadyRedeemed,
+                cashRedeemedNow: !isPainter && !cashAlreadyRedeemed,
             });
 
             if (!updatedTransaction) {
@@ -605,7 +628,8 @@ class TransactionService {
             //   coupon.value             → User.cash
             // Tracks already redeemed earlier stay at 0 and are not double-credited.
             const pointsReward = pointsAlreadyRedeemed ? 0 : (updatedTransaction.redeemablePoints || 0);
-            const cashReward   = cashAlreadyRedeemed   ? 0 : (updatedTransaction.value             || 0);
+            // Painters only get points; cash is skipped for them entirely
+            const cashReward = (!isPainter && !cashAlreadyRedeemed) ? (updatedTransaction.value || 0) : 0;
 
             let userData = req.user;
             if (pointsReward > 0 || cashReward > 0) {

--- a/tests/controllers/services/transactionService.test.js
+++ b/tests/controllers/services/transactionService.test.js
@@ -34,7 +34,7 @@ const DEALER_ID = new mongoose.Types.ObjectId();
 
 const DEALER_USER = { _id: DEALER_ID, mobile: '9000000001', accountType: 'Dealer', dealerCode: 'D001', rewardPoints: 500 };
 const PAINTER_ID = new mongoose.Types.ObjectId();
-const PAINTER_USER = { _id: PAINTER_ID, mobile: '9000000002', accountType: 'Painter', dealerCode: 'P001', rewardPoints: 200 };
+const PAINTER_USER = { _id: PAINTER_ID, mobile: '9000000002', accountType: 'Painter', parentDealerCode: 'D001', rewardPoints: 200 };
 
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -524,9 +524,33 @@ describe('TransactionService', () => {
             expect(transactionLedger.create).not.toHaveBeenCalled();
         });
 
-        // ─── Painter happy path (eligibility wiring) ──────────────────────
+        // ─── Painter: points only, authorized via parentDealerCode ──────
 
-        test('credits a Painter user the same way as a Dealer', async () => {
+        test('returns 403 if Painter has no parentDealerCode', async () => {
+            const req = { user: { ...PAINTER_USER, parentDealerCode: undefined }, body: { qrCodeUrl: QR_URL } };
+            const res = makeRes();
+
+            await TransactionService.redeemCouponPoints(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(403);
+            expect(res.json).toHaveBeenCalledWith({ message: 'Parent dealer code not set. Contact support.' });
+            expect(getDealerAccountId).not.toHaveBeenCalled();
+        });
+
+        test('returns 403 if Painter parentDealerCode not found in Focus8', async () => {
+            const req = { user: { ...PAINTER_USER }, body: { qrCodeUrl: QR_URL } };
+            const res = makeRes();
+
+            getDealerAccountId.mockResolvedValue(null);
+
+            await TransactionService.redeemCouponPoints(req, res);
+
+            expect(getDealerAccountId).toHaveBeenCalledWith('D001');
+            expect(res.status).toHaveBeenCalledWith(403);
+            expect(res.json).toHaveBeenCalledWith({ message: 'Parent dealer not found in Focus8. Contact support.' });
+        });
+
+        test('Painter authorized via parentDealerCode credits points only', async () => {
             const req = { user: { ...PAINTER_USER }, body: { qrCodeUrl: QR_URL } };
             const res = makeRes();
 
@@ -537,10 +561,9 @@ describe('TransactionService', () => {
             };
             const updatedTxn = { ...coupon,
                 pointsRedeemedBy: PAINTER_USER.mobile,
-                cashRedeemedBy:   PAINTER_USER.mobile,
                 updatedBy: PAINTER_ID,
             };
-            const updatedUser = { ...PAINTER_USER, rewardPoints: 280, cash: 40 };
+            const updatedUser = { ...PAINTER_USER, rewardPoints: 280 };
 
             getDealerAccountId.mockResolvedValue(55);
             Transaction.findOne = jest.fn().mockResolvedValue(coupon);
@@ -550,22 +573,55 @@ describe('TransactionService', () => {
 
             await TransactionService.redeemCouponPoints(req, res);
 
-            expect(getDealerAccountId).toHaveBeenCalledWith('P001');
+            // Must use parentDealerCode for Focus8 lookup, not dealerCode
+            expect(getDealerAccountId).toHaveBeenCalledWith('D001');
+
+            // Coupon update must NOT touch the cash track
+            const setArg = Transaction.findOneAndUpdate.mock.calls[0][1].$set;
+            expect(setArg).toHaveProperty('pointsRedeemedBy', PAINTER_USER.mobile);
+            expect(setArg).not.toHaveProperty('cashRedeemedBy');
+            expect(setArg).not.toHaveProperty('cashRedeemedAt');
+
+            // Only rewardPoints incremented — cash must not appear in $inc
             expect(User.findOneAndUpdate).toHaveBeenCalledWith(
                 { _id: PAINTER_ID },
-                { $inc: { rewardPoints: 80, cash: 40 } },
+                { $inc: { rewardPoints: 80 } },
                 { new: true }
             );
+
+            // Ledger row has zero cash fields
             expect(transactionLedger.create).toHaveBeenCalledTimes(1);
             expect(transactionLedger.create).toHaveBeenCalledWith(expect.objectContaining({
                 pointsCredited: 80, pointsBalance: 280,
-                cashReward: 40, cashBalance: 40,
-                narration: expect.stringMatching(/80 pts \+ 40 cash credited/i),
+                cashReward: 0,
+                narration: expect.stringMatching(/80 pts credited/i),
             }));
+
             expect(res.status).toHaveBeenCalledWith(200);
             expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
-                data: { rewardPoints: 80, cashReward: 40, couponCode: 'C008' },
+                data: { rewardPoints: 80, cashReward: 0, couponCode: 'C008' },
             }));
+        });
+
+        test('Painter gets 404 once points track is taken (even if cash track is open)', async () => {
+            const req = { user: { ...PAINTER_USER }, body: { qrCodeUrl: QR_URL } };
+            const res = makeRes();
+
+            Transaction.findOne = jest.fn().mockResolvedValue({
+                _id: 'txn2', UDID: 'TEST-UDID-001', couponCode: 'C009',
+                redeemablePoints: 80, value: 40,
+                pointsRedeemedBy: '9000000099',   // already taken
+                cashRedeemedBy: undefined,          // cash still open — irrelevant for Painter
+            });
+            Transaction.findOneAndUpdate = jest.fn();
+            User.findOneAndUpdate = jest.fn();
+            transactionLedger.create = jest.fn();
+
+            await TransactionService.redeemCouponPoints(req, res);
+
+            expect(res.status).toHaveBeenCalledWith(404);
+            expect(res.json).toHaveBeenCalledWith({ message: 'Coupon Redeemed already.' });
+            expect(Transaction.findOneAndUpdate).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
…rCode

Painters can now redeem coupons via QR scan (points track only). Authorization uses parentDealerCode → Focus8 dealer lookup instead of the painter's own dealerCode. Dealers continue redeeming both points and cash tracks unchanged. Added 4 Painter-specific tests (20 total).