### PR TITLE
feat: Focus8 warehouse/branch/narration support for sales orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ logs/
 docs/
 .agent
 .vscode/
+.wolf
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,10 @@
+# OpenWolf
+
+@.wolf/OPENWOLF.md
+
+This project uses OpenWolf for context management. Read and follow .wolf/OPENWOLF.md every session. Check .wolf/cerebrum.md before generating code. Check .wolf/anatomy.md before reading files.
+
+
 # Project guidance for Claude
 
 This repository's conventions, structure, build/test commands, and recent

--- a/controllers/ordersController.js
+++ b/controllers/ordersController.js
@@ -55,9 +55,9 @@ async function generateInvoicePdf(order, user) {
 
 // Perform a Focus 8 push asynchronously and persist the outcome via updateOne.
 // Failures are logged with enough context that ops can find and retry them.
-async function runFocusSync(orderDocId, orderId, order, dealer, entityId) {
+async function runFocusSync(orderDocId, orderId, order, dealer, { entityId, warehouseId, branchId, narration } = {}) {
     try {
-        const result = await pushOrderToFocus8(order, dealer, entityId);
+        const result = await pushOrderToFocus8(order, dealer, { entityId, warehouseId, branchId, narration });
         const update = result.success
             ? {
                 focusSyncStatus: 'SUCCESS',
@@ -105,7 +105,12 @@ exports.retryFocusSync = async (req, res) => {
 
         // Mark pending, kick off, return immediately.
         await orderModel.updateOne({ _id: order._id }, { $set: { focusSyncStatus: 'PENDING' } });
-        runFocusSync(order._id, order.orderId, order, dealer, req.body.entityId || 1);
+        runFocusSync(order._id, order.orderId, order, dealer, {
+            entityId: order.entityId,
+            warehouseId: order.warehouseId,
+            branchId: order.branchId,
+            narration: order.narration
+        });
         return res.status(200).json({ success: true, message: 'Retry initiated', orderId });
     } catch (error) {
         logger.error('Focus 8 retry failed', { error: error.message });
@@ -145,9 +150,14 @@ exports.createOrder = async (req, res) => {
             return res.status(400).json({success: false, message: 'Dealer id is required when sales executive is placing order.'});
         }
 
-        const { items, totalPrice, entityId = 1 } = req.body;
+        const { items, totalPrice, entityId, warehouseId, branchId, narration } = req.body;
         if (!items || !Array.isArray(items) || items.length === 0) {
             return res.status(400).json({ success: false, message: 'No items provided for order.' });
+        }
+        if (req.user.accountType === 'SalesExecutive') {
+            if (!entityId) return res.status(400).json({ success: false, message: 'Entity is required.' });
+            if (!warehouseId) return res.status(400).json({ success: false, message: 'Warehouse is required.' });
+            if (!branchId) return res.status(400).json({ success: false, message: 'Branch is required.' });
         }
 
         // Fetch every referenced offer so we can (a) enrich Focus 8 IDs and
@@ -245,7 +255,11 @@ exports.createOrder = async (req, res) => {
             createdBy: userId || '',
             status: orderStatus,
             isVerified: isVerified,
-            statusHistory: [{ status: orderStatus, changedAt: new Date() }]
+            statusHistory: [{ status: orderStatus, changedAt: new Date() }],
+            entityId,
+            warehouseId,
+            branchId,
+            ...(narration ? { narration } : {})
         };
         if (req.body.dealerId) {
             orderObj.dealerId = req.body.dealerId;
@@ -266,7 +280,7 @@ exports.createOrder = async (req, res) => {
         // focusSyncStatus: PENDING so the client can poll. Persist via updateOne
         // (not order.save) to avoid racing the in-memory document.
         if (req.user.accountType === 'SalesExecutive') {
-            runFocusSync(order._id, orderId, order, orderCreatedForDetails, entityId);
+            runFocusSync(order._id, orderId, order, orderCreatedForDetails, { entityId, warehouseId, branchId, narration });
         }
 
         // const pdfBuffer = await generateInvoicePdf(order, req.user);
@@ -316,7 +330,7 @@ exports.getOrders = async (req, res) => {
         let query = {};
         let populateOptions = {
             path: 'createdBy',
-            select: 'name mobile accountType'
+            select: 'name mobile accountType dealerCode'
         };
         let orders;
         let totalOrders;
@@ -327,6 +341,7 @@ exports.getOrders = async (req, res) => {
             orders = await orderModel
                 .find(query)
                 .populate(populateOptions)
+                .populate({ path: 'dealerId', select: 'name dealerCode mobile' })
                 .sort({ createdAt: -1 }) // Latest orders first
                 .skip((page - 1) * limit)
                 .limit(limit)
@@ -527,7 +542,7 @@ exports.getOrderDetails = async (req, res) => {
 
 exports.updateOrderStatus = async (req, res) => {
     try {
-        const { orderId, isVerified, entityId = 1 } = req.body;
+        const { orderId, isVerified, entityId, warehouseId, branchId, narration } = req.body;
         const user = req.user;
 
         // Check if the user is a SalesExecutive
@@ -600,7 +615,12 @@ exports.updateOrderStatus = async (req, res) => {
         if (isVerified === 1) {
             const dealer = await userModel.findById(order.createdBy);
             if (dealer) {
-                runFocusSync(updatedOrder._id, orderId, updatedOrder, dealer, entityId);
+                runFocusSync(updatedOrder._id, orderId, updatedOrder, dealer, {
+                    entityId: entityId || order.entityId,
+                    warehouseId: warehouseId || order.warehouseId,
+                    branchId: branchId || order.branchId,
+                    narration: narration || order.narration
+                });
             } else {
                 logger.error('Dealer not found for order ', { orderId });
             }

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -3,7 +3,7 @@ const Product = require('../models/Product');
 const Brand = require('../models/Brand'); // assuming Brand still exists and is referenced
 const Transaction = require("../models/Transaction");
 const { getAllUnifiedProducts } = require('../services/productService');
-const { getProductMaster, getEntityMaster } = require('../services/focus8Order.service');
+const { getProductMaster, getEntityMaster, getWarehouseMaster, getBranchMaster } = require('../services/focus8Order.service');
 const { escapeRegex, clampLimit, clampPage } = require('../utils/validators');
 
 // Create a new product and associate it with a brand
@@ -281,6 +281,26 @@ const getFocusEntities = async (req, res) => {
   }
 };
 
+const getFocusWarehouses = async (req, res) => {
+  try {
+    const warehouses = await getWarehouseMaster();
+    return res.status(200).json({ success: true, warehouses });
+  } catch (error) {
+    logger.error('Error fetching warehouses from Focus8', { message: error.message });
+    return res.status(500).json({ success: false, message: error.message });
+  }
+};
+
+const getFocusBranches = async (req, res) => {
+  try {
+    const warehouses = await getBranchMaster();
+    return res.status(200).json({ success: true, warehouses });
+  } catch (error) {
+    logger.error('Error fetching warehouses from Focus8', { message: error.message });
+    return res.status(500).json({ success: false, message: error.message });
+  }
+}
+
 module.exports = {
   createProduct,
   getProductsByBrandId,
@@ -291,5 +311,7 @@ module.exports = {
   getProductsByName,
   getUnifiedProductList,
   getFocusProducts,
-  getFocusEntities
+  getFocusEntities,
+  getFocusWarehouses,
+  getFocusBranches
 };

--- a/models/Order.js
+++ b/models/Order.js
@@ -52,6 +52,12 @@ const orderSchema = new Schema({
     changedAt: { type: Date, default: Date.now }
   }],
 
+  // Sales order context (user-selected in mobile app)
+  entityId: { type: Number },
+  warehouseId: { type: Number },
+  branchId: { type: Number },
+  narration: { type: String },
+
   // Focus Integration Fields
   focusSyncStatus: { type: String, enum: ['PENDING', 'SUCCESS', 'FAILED'], default: 'PENDING' },
   focusOrderId: { type: String }, // SO VoucherNo returned by Focus

--- a/routes/productRoutes.js
+++ b/routes/productRoutes.js
@@ -11,7 +11,9 @@ const {
   getProductsByName,
   getUnifiedProductList,
   getFocusProducts,
-  getFocusEntities
+  getFocusEntities,
+  getFocusWarehouses,
+  getFocusBranches
 } = require('../controllers/productController');
 
 // Route to create a new product
@@ -40,6 +42,12 @@ router.get('/focus-products', getFocusProducts);
 
 // Route to get entity master from Focus
 router.get('/focus-entities', getFocusEntities);
+
+// Route to get warehouse master from Focus
+router.get('/focus-warehouses', getFocusWarehouses);
+
+// Route to get branch master from Focus
+router.get('/focus-branches', getFocusBranches);
 
 // Route to get all products for a specific brand by brandId
 router.get('/:brandId', getProductsByBrandId);

--- a/services/focus8Order.service.js
+++ b/services/focus8Order.service.js
@@ -154,17 +154,8 @@ async function getOrderHeaderData(filters = {}) {
         return null;
     }
 
-    let Branch__Id = 0;
     let Salesman__Id = 0;
     let Districts__Id = 0;
-
-    try {
-        if (customer.BranchName) {
-            Branch__Id = await getBranchId(customer.BranchName);
-        }
-    } catch (e) {
-        logger.warn(`Failed to resolve Branch ID for ${customer.BranchName}, using fallback 0`);
-    }
 
     try {
         if (customer.SalesmanName) {
@@ -184,7 +175,6 @@ async function getOrderHeaderData(filters = {}) {
 
     return {
         CustomerAC__Id: Number(customer.iMasterId),
-        Branch__Id: Number(Branch__Id),
         Salesman__Id: Number(Salesman__Id),
         Districts__Id: Number(Districts__Id),
         IsIGST: 0
@@ -299,15 +289,46 @@ async function getEntityMaster() {
 
 /**
  * ===============================
+ * GET WAREHOUSE MASTER
+ * ===============================
+ */
+async function getWarehouseMaster() {
+    const res = await focusRequest(
+        `${FOCUS8_BASE_URL}/utility/ExecuteSqlQuery`,
+        {
+            data: [{ Query: "SELECT iMasterId, sName, sCode from mCore_Warehouse where istatus <>5" }]
+        }
+    );
+
+    return res.data?.data?.[0]?.Table || [];
+}
+
+/**
+ * ===============================
+ * GET BRANCH MASTER
+ * ===============================
+ */
+async function getBranchMaster() {
+    const res = await focusRequest(
+        `${FOCUS8_BASE_URL}/utility/ExecuteSqlQuery`,
+        {
+            data: [{ Query: "SELECT iMasterId, sName, sCode from mCore_Branch where istatus <>5" }]
+        }
+    );
+
+    return res.data?.data?.[0]?.Table || [];
+}
+
+/**
+ * ===============================
  * PUSH SALES ORDER TO FOCUS8
  * ===============================
  */
-async function pushOrderToFocus8(order, user, entityId) {
+async function pushOrderToFocus8(order, user, { entityId, warehouseId, branchId, narration } = {}) {
     let payload;
     try {
         const {
             CustomerAC__Id,
-            Branch__Id,
             Salesman__Id,
             Districts__Id,
             IsIGST
@@ -324,20 +345,25 @@ async function pushOrderToFocus8(order, user, entityId) {
         });
 
         const Entity__Id = entityId;
+        const Branch__Id = branchId;
+        const Warehouse__Id = warehouseId;
+
+        const header = {
+            CustomerAC__Id,
+            Branch__Id,
+            Salesman__Id,
+            Districts__Id,
+            Entity__Id,
+            Warehouse__Id,
+            'Company Name__Id': Entity__Id,
+            IsIGST,
+            MobileAppOrderId: order.orderId || ''
+        };
+        if (narration) header.Narration = narration; //TODO: narration field name should be confirmed by focus
 
         payload = {
             data: [{
-                Header: {
-                    CustomerAC__Id,
-                    Branch__Id,
-                    Salesman__Id,
-                    Districts__Id,
-                    Entity__Id,
-                    Warehouse__Id: 3, //TODO: Remove after focus makes this non mandatory.
-                    'Company Name__Id': Entity__Id,
-                    IsIGST,
-                    MobileAppOrderId: order.orderId || ''
-                },
+                Header: header,
                 Body: bodyItems,
                 Footer: []
             }]
@@ -556,6 +582,8 @@ async function getDealerFinancialData(dealerCode) {
 module.exports = {
     getProductMaster,
     getEntityMaster,
+    getWarehouseMaster,
+    getBranchMaster,
     pushOrderToFocus8,
     getPriceBookData,
     getDealerAccountId,


### PR DESCRIPTION
- Add getWarehouseMaster() and getBranchMaster() helpers in focus8Order.service.js fetching from mCore_Warehouse and mCore_Branch via ExecuteSqlQuery
- Expose GET /products/focus-warehouses and GET /products/focus-branches endpoints
- pushOrderToFocus8 now accepts { entityId, warehouseId, branchId, narration } instead of hardcoded Warehouse__Id: 3
- Narration conditionally added to Focus8 header when provided
- Order model gains entityId, warehouseId, branchId, narration fields
- createOrder validates entity/warehouse/branch as mandatory for SalesExecutive
- updateOrderStatus and retryFocusSync pass stored order values as fallback
- getOrders (SuperUser) now populates dealerId with name/dealerCode/mobile