### PR TITLE
feat: product categories master — offer/dealer category tagging and f…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,54 @@ All 114 tests across 6 suites pass (`npx jest tests/controllers/ --no-coverage`)
 
 ---
 
+### Product Categories master + offer/dealer category tagging (as of 2026-05-03)
+
+A new **Product Categories** master entity replaces the `routeScheme` SE-mobile filter for controlling which dealers see which product offers.
+
+#### Backend — new files
+- `models/ProductCategory.js` — Mongoose model for `productcategories` collection. Fields: `name` (String, required, unique). ObjectId `_id` is the canonical key.
+- `controllers/productCategoryController.js` — full CRUD: `createProductCategory`, `getProductCategories` (sorted by name), `updateProductCategory`, `deleteProductCategory`. Whitespace-only names are rejected (`!name || !name.trim()`). Duplicate-check on update excludes self via `{ _id: { $ne: req.params.id } }`.
+- `routes/productCategoryRoutes.js` — JWT auth applied to all routes via `router.use(passport.authenticate('jwt', { session: false }))`. `POST /`, `PUT /:id`, `DELETE /:id` require `requireRole(ADMIN)`; `GET /all` is authenticated-only.
+
+#### Backend — changed files
+- `routes/index.js` — registered `productCategoryRoutes` at `/productCategories`.
+- `models/User.js` — added `productCategories: [{ type: Schema.Types.ObjectId, ref: 'ProductCategory' }]` (array of ObjectId refs; used to tag dealers with their visible offer categories).
+- `models/productOffers.model.js` — added `productCategory: { type: Schema.Types.ObjectId, ref: 'ProductCategory', default: null }`. Legacy `routeScheme` field removed from schema (field still exists in DB — harmless).
+- `controllers/productOffers.controller.js`:
+  - `createProductOffer` — accepts `req.body.productCategory` and saves it on the new document.
+  - `updateProductOffer` — includes `productCategory: req.body.productCategory || null` in the `findByIdAndUpdate` payload.
+  - `searchProductOffers` — replaced routeScheme filter with category-based logic:
+    - **Dealer**: `{ productCategory: { $in: dealer.productCategories } }` — sees only offers matching their tagged categories.
+    - **SalesExecutive**: `{ productCategory: { $ne: null, $exists: true } }` — sees all offers that have a category set.
+    - **SuperUser**: no additional filter — sees all offers including those with `productCategory: null`.
+- `controllers/userController.js` — added `'productCategories'` to `USER_ALLOWED_CREATE_FIELDS` whitelist. Without this, `pickFields()` silently stripped the field before `updateOne`, making category saves on dealers a silent no-op.
+- `database/mongoose.js` — added startup code to `dropIndex('categoryId_1')` on the `productcategories` collection, swallowing `IndexNotFound` errors. Required because a prior version of the model had a `categoryId` unique field; the stale index persisted in MongoDB after the field was removed from the schema and caused `E11000` duplicate-key errors on every second insert.
+
+#### Frontend — new files (`aultra-paints-frontend/src/app/product-category-list/`)
+- `product-category-list.component.ts` — standalone Angular component; CRUD via `apiRequestService.*Master()` methods.
+- `product-category-list.component.html` — table (S.NO, Category Name, Actions) with inline add/edit modal (single `name` field).
+- `product-category-list.component.css` — empty placeholder.
+
+#### Frontend — changed files
+- `src/app/services/api-urls.service.ts` — added `createProductCategory`, `getProductCategories`, `updateProductCategory`, `deleteProductCategory` URL constants.
+- `src/app/services/api-request.service.ts` — added `getProductCategories()`, `createProductCategoryMaster()`, `updateProductCategoryMaster()`, `deleteProductCategoryMaster()` methods (named `*Master` to avoid collision with the existing `deleteProductCategory` catalog method).
+- `src/app/app.routes.ts` — added `{ path: 'product-category-list', component: ProductCategoryListComponent, canActivate: [RoleGuard], data: { roles: ADMIN } }`.
+- `src/app/layout/layout.component.html` — added "Product Categories" nav item to the Masters submenu (`bx-category` icon).
+- `src/app/product-offers/product-offers.component.ts` — replaced `salesExecutives`/`loadSalesExecutives()` with `productCategories`/`loadProductCategories()`; replaced `routeScheme: []` default with `productCategory: null`; removed `getSeName()`/`asArray()` helpers; added `getCategoryName(id)` lookup; FormData now sends `productCategory` instead of `routeScheme`.
+- `src/app/product-offers/product-offers.component.html` — replaced Route Scheme multi-select with a single-select `ng-select` bound to `currentOffer.productCategory` (`bindValue="_id"`).
+- `src/app/user-list/user-list.component.ts` — added `NgSelectModule`, `productCategories[]`, `loadProductCategories()`, manual validation in `submitForm()` and `updateUser()` (Angular `[required]` on `ng-select` does not integrate with template-driven form validation — explicit JS guard required for Dealer accountType).
+- `src/app/user-list/user-list.component.html` — added product-categories multi-select (`bindValue="_id"`, `[multiple]="true"`) in both Add and Edit dealer modals.
+
+#### Tests
+- `tests/controllers/productCategoryController.test.js` *(new)* — 18 tests covering all four CRUD operations including whitespace rejection, duplicate-name self-exclusion on update, 404 handling, and DB errors.
+- `tests/controllers/productOffers.controller.test.js` — replaced `routeScheme filtering` describe with `productCategory filtering` (7 tests: Dealer `$in` filter, SE non-null filter, SuperUser no filter, search query combined with `$and`); added 4 tests for `createProductOffer`/`updateProductOffer` productCategory handling.
+- `tests/controllers/userController.test.js` — added `userUpdate — productCategories` describe (5 tests: field passes whitelist, empty array preserved, absent when not provided, correct `_id` filter, 400 on missing mobile).
+- `tests/controllers/ordersController.test.js` — fixed 2 pre-existing failures: SE order tests now include `entityId`, `warehouseId`, `branchId` in `req.body` (required fields added in the Focus8 warehouse/branch feature; tests were not updated at that time).
+
+**Total test suite: 149 tests across 7 suites, all passing.**
+
+---
+
 ## Latest Scanned Code Changes (as of 2026-02-28)
 - Added Focus8-related pricing/effective-date logic in `services/focus8Order.service.js` and `controllers/productCatlogController.js`.
 - Credit note flow was updated across `controllers/transactionLedgerController.js`, `templates/creditNoteTemplate.html`, and `utils/pdfGenerator.js`.

--- a/controllers/productCategoryController.js
+++ b/controllers/productCategoryController.js
@@ -1,0 +1,67 @@
+const ProductCategory = require('../models/ProductCategory');
+
+exports.createProductCategory = async (req, res) => {
+    try {
+        const { name } = req.body;
+        if (!name || !name.trim()) {
+            return res.status(400).json({ message: 'Category name is required.' });
+        }
+        const existing = await ProductCategory.findOne({ name: name.trim() });
+        if (existing) {
+            return res.status(400).json({ message: 'Category name already exists.' });
+        }
+        const category = new ProductCategory({ name: name.trim() });
+        await category.save();
+        return res.status(201).json({ message: 'Product category created successfully', data: category });
+    } catch (err) {
+        return res.status(500).json({ message: 'Internal Server Error', error: err.message });
+    }
+};
+
+exports.getProductCategories = async (req, res) => {
+    try {
+        const categories = await ProductCategory.find().sort({ name: 1 });
+        return res.status(200).json({ data: categories });
+    } catch (err) {
+        return res.status(500).json({ message: 'Internal Server Error', error: err.message });
+    }
+};
+
+exports.updateProductCategory = async (req, res) => {
+    try {
+        const { name } = req.body;
+        if (!name || !name.trim()) {
+            return res.status(400).json({ message: 'Category name is required.' });
+        }
+        const existing = await ProductCategory.findOne({
+            name: name.trim(),
+            _id: { $ne: req.params.id }
+        });
+        if (existing) {
+            return res.status(400).json({ message: 'Category name already exists.' });
+        }
+        const category = await ProductCategory.findByIdAndUpdate(
+            req.params.id,
+            { name: name.trim() },
+            { new: true }
+        );
+        if (!category) {
+            return res.status(404).json({ message: 'Product category not found.' });
+        }
+        return res.status(200).json({ message: 'Product category updated successfully', data: category });
+    } catch (err) {
+        return res.status(500).json({ message: 'Internal Server Error', error: err.message });
+    }
+};
+
+exports.deleteProductCategory = async (req, res) => {
+    try {
+        const category = await ProductCategory.findByIdAndDelete(req.params.id);
+        if (!category) {
+            return res.status(404).json({ message: 'Product category not found.' });
+        }
+        return res.status(200).json({ message: 'Product category deleted successfully' });
+    } catch (err) {
+        return res.status(500).json({ message: 'Internal Server Error', error: err.message });
+    }
+};

--- a/controllers/productOffers.controller.js
+++ b/controllers/productOffers.controller.js
@@ -15,30 +15,11 @@ async function generateThumbnail(imageBuffer) {
         .toBuffer();
 }
 
-/**
- * Parse routeScheme from a FormData field.
- * Accepts: JSON array string '["m1","m2"]', single string "m1", empty string, or null.
- * Returns: non-empty string[] or null (null means "show to all dealers").
- */
-function parseRouteScheme(raw) {
-    if (!raw) return null;
-    let parsed;
-    try {
-        parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
-    } catch {
-        parsed = raw; // treat as plain string
-    }
-    if (Array.isArray(parsed)) {
-        const filtered = parsed.filter(Boolean);
-        return filtered.length ? filtered : null;
-    }
-    return parsed || null;
-}
 
 // Create a new productOffer
 exports.createProductOffer = async (req, res) => {
     let {productOfferDescription, validUntil, productOfferStatus, cashback, redeemPoints, price} = req.body;
-    const routeScheme = parseRouteScheme(req.body.routeScheme);
+    const productCategory = req.body.productCategory || null;
     if (!req.body.productOfferImage) {
         return res.status(400).json({message: 'Image is required'});
     }
@@ -76,7 +57,7 @@ exports.createProductOffer = async (req, res) => {
         cashback,
         redeemPoints,
         price : parsedPrice,
-        routeScheme: routeScheme || null
+        productCategory
     });
 
     try {
@@ -228,25 +209,25 @@ exports.searchProductOffers = async (req, res) => {
         }
         query['offerAvailable'] = true;
 
-        // SuperUser sees all offers regardless of route scheme.
-        // Dealers and SalesExecutives are filtered to their own route.
-        if (req.user.accountType !== 'SuperUser') {
-            let seMobile = null;
-            if (req.user.accountType === 'Dealer') {
-                seMobile = req.user.salesExecutive || null;
-            } else if (req.user.accountType === 'SalesExecutive') {
-                seMobile = req.user.mobile;
-            }
-            const routeSchemeFilter = { $or: [
-                { routeScheme: null },
-                { routeScheme: { $exists: false } },
-                { routeScheme: seMobile }
-            ]};
+        // SuperUser sees all offers regardless of product category.
+        // Dealers see only offers whose productCategory matches one of their assigned categories.
+        // SalesExecutives see all offers that have a productCategory set.
+        if (req.user.accountType === 'Dealer') {
+            const dealerCategories = req.user.productCategories || [];
+            const categoryFilter = { productCategory: { $in: dealerCategories } };
             if (query['$or']) {
-                query['$and'] = [{ $or: query['$or'] }, routeSchemeFilter];
+                query['$and'] = [{ $or: query['$or'] }, categoryFilter];
                 delete query['$or'];
             } else {
-                query['$or'] = routeSchemeFilter['$or'];
+                Object.assign(query, categoryFilter);
+            }
+        } else if (req.user.accountType === 'SalesExecutive') {
+            const seCategoryFilter = { productCategory: { $ne: null, $exists: true } };
+            if (query['$or']) {
+                query['$and'] = [{ $or: query['$or'] }, seCategoryFilter];
+                delete query['$or'];
+            } else {
+                Object.assign(query, seCategoryFilter);
             }
         }
 
@@ -378,7 +359,7 @@ exports.updateProductOffer = async (req, res) => {
             productOfferImageUrl: req.body.productOfferImageUrl,
             updatedBy: req.body.updatedBy,
             price: parsedPrice,
-            routeScheme: parseRouteScheme(req.body.routeScheme),
+            productCategory: req.body.productCategory || null,
             productOfferThumbnailUrl: req.body.productOfferThumbnailUrl,
         };
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -15,7 +15,7 @@ const USER_PROTECTED_FIELDS = ['rewardPoints', 'cash', 'legacyCash', 'token', '_
 const USER_ALLOWED_CREATE_FIELDS = [
     'name', 'mobile', 'address', 'email', 'primaryContactPerson', 'primaryContactPersonMobile',
     'dealerCode', 'parentDealerCode', 'accountType', 'upiID', 'salesExecutive',
-    'state', 'zone', 'district', 'status'
+    'state', 'zone', 'district', 'status', 'productCategories'
 ];
 const USER_ALLOWED_UPDATE_FIELDS = USER_ALLOWED_CREATE_FIELDS.filter(f => f !== 'accountType');
 

--- a/models/ProductCategory.js
+++ b/models/ProductCategory.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const productCategorySchema = new mongoose.Schema({
+    name: { type: String, required: true, unique: true }
+}, { timestamps: true });
+
+const ProductCategory = mongoose.model('ProductCategory', productCategorySchema);
+
+module.exports = ProductCategory;

--- a/models/User.js
+++ b/models/User.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { Schema } = mongoose;
 
 const userSchema = new mongoose.Schema({
     name: {type: String, required: true},
@@ -22,7 +23,8 @@ const userSchema = new mongoose.Schema({
     salesExecutive: {type: String},
     state: { type: String },
     zone: { type: String },
-    district: { type: String }
+    district: { type: String },
+    productCategories: [{ type: Schema.Types.ObjectId, ref: 'ProductCategory' }]
 }, {timestamps: true})
 
 const User = mongoose.model('User', userSchema);

--- a/models/productOffers.model.js
+++ b/models/productOffers.model.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { Schema } = mongoose;
 
 const productOffersSchema = new mongoose.Schema({
     productOfferImageUrl: { type: String },
@@ -18,7 +19,7 @@ const productOffersSchema = new mongoose.Schema({
         }
     ],
     offerAvailable: { type: Boolean, default: true },
-    routeScheme: { type: [String], default: null },
+    productCategory: { type: Schema.Types.ObjectId, ref: 'ProductCategory', default: null },
     focusProductId: {type: Number},
     focusUnitId: {type: Number},
     focusProductMapping: [{

--- a/routes/index.js
+++ b/routes/index.js
@@ -19,6 +19,7 @@ const productCatlogRoutes = require('./productCatlogRoutes.js');
 const orderRoutes = require('./orderRoutes.js');
 const chartRoutes = require('./chartRoutes');
 const creditNoteRoutes = require('./creditNote.route');
+const productCategoryRoutes = require('./productCategoryRoutes');
 
 /** GET /health-check - Check service health */
 router.get('/health-check', (req, res) => res.send('OK'));
@@ -42,5 +43,6 @@ router.use('/productCatlog', productCatlogRoutes);
 router.use('/order', orderRoutes);
 router.use('/chart', chartRoutes);
 router.use('/creditNotes', creditNoteRoutes);
+router.use('/productCategories', productCategoryRoutes);
 
 module.exports = router;

--- a/routes/productCategoryRoutes.js
+++ b/routes/productCategoryRoutes.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const passport = require('passport');
+const { requireRole, ADMIN } = require('../middleware/authorize');
+const productCategoryController = require('../controllers/productCategoryController');
+
+router.use(passport.authenticate('jwt', { session: false }));
+
+router.post('/', requireRole(ADMIN), productCategoryController.createProductCategory);
+router.get('/all', productCategoryController.getProductCategories);
+router.put('/:id', requireRole(ADMIN), productCategoryController.updateProductCategory);
+router.delete('/:id', requireRole(ADMIN), productCategoryController.deleteProductCategory);
+
+module.exports = router;

--- a/tests/controllers/ordersController.test.js
+++ b/tests/controllers/ordersController.test.js
@@ -282,7 +282,7 @@ describe('createOrder', () => {
 
         const req = {
             user: seUser,
-            body: { items: baseItems(), totalPrice: 200, dealerId: DEALER_ID },
+            body: { items: baseItems(), totalPrice: 200, dealerId: DEALER_ID, entityId: 'E1', warehouseId: 'W1', branchId: 'B1' },
         };
         await ordersController.createOrder(req, res);
 
@@ -305,7 +305,7 @@ describe('createOrder', () => {
 
         const req = {
             user: seUser,
-            body: { items: baseItems(), totalPrice: 200, dealerId: DEALER_ID },
+            body: { items: baseItems(), totalPrice: 200, dealerId: DEALER_ID, entityId: 'E1', warehouseId: 'W1', branchId: 'B1' },
         };
         await ordersController.createOrder(req, res);
 

--- a/tests/controllers/productCategoryController.test.js
+++ b/tests/controllers/productCategoryController.test.js
@@ -1,0 +1,284 @@
+jest.mock('../../models/ProductCategory');
+jest.mock('../../utils/logger', () => ({
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+}));
+
+const mongoose = require('mongoose');
+const ProductCategory = require('../../models/ProductCategory');
+const {
+    createProductCategory,
+    getProductCategories,
+    updateProductCategory,
+    deleteProductCategory,
+} = require('../../controllers/productCategoryController');
+
+function makeRes() {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json   = jest.fn().mockReturnValue(res);
+    return res;
+}
+
+const CAT_ID   = new mongoose.Types.ObjectId();
+const MOCK_CAT = { _id: CAT_ID, name: 'Interior', createdAt: new Date(), updatedAt: new Date() };
+
+beforeEach(() => jest.clearAllMocks());
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createProductCategory
+// ─────────────────────────────────────────────────────────────────────────────
+describe('createProductCategory', () => {
+    test('201 with created category on success', async () => {
+        ProductCategory.findOne.mockResolvedValue(null);
+        const saveMock = jest.fn().mockResolvedValue(MOCK_CAT);
+        ProductCategory.mockImplementation(() => ({ save: saveMock }));
+
+        const req = { body: { name: 'Interior' } };
+        const res = makeRes();
+
+        await createProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(201);
+        const body = res.json.mock.calls[0][0];
+        expect(body.message).toMatch(/created successfully/i);
+    });
+
+    test('400 when name is missing', async () => {
+        const req = { body: {} };
+        const res = makeRes();
+
+        await createProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json.mock.calls[0][0].message).toMatch(/required/i);
+        expect(ProductCategory.findOne).not.toHaveBeenCalled();
+    });
+
+    test('400 when name is empty string', async () => {
+        const req = { body: { name: '   ' } };
+        const res = makeRes();
+
+        await createProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    test('400 when a category with the same name already exists', async () => {
+        ProductCategory.findOne.mockResolvedValue(MOCK_CAT);
+
+        const req = { body: { name: 'Interior' } };
+        const res = makeRes();
+
+        await createProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json.mock.calls[0][0].message).toMatch(/already exists/i);
+    });
+
+    test('name is trimmed before duplicate check and save', async () => {
+        ProductCategory.findOne.mockResolvedValue(null);
+        const saveMock = jest.fn().mockResolvedValue(MOCK_CAT);
+        ProductCategory.mockImplementation(() => ({ save: saveMock }));
+
+        const req = { body: { name: '  Interior  ' } };
+        const res = makeRes();
+
+        await createProductCategory(req, res);
+
+        expect(ProductCategory.findOne).toHaveBeenCalledWith({ name: 'Interior' });
+        // Constructor called with trimmed name
+        expect(ProductCategory).toHaveBeenCalledWith({ name: 'Interior' });
+    });
+
+    test('500 on unexpected DB error', async () => {
+        ProductCategory.findOne.mockRejectedValue(new Error('DB down'));
+
+        const req = { body: { name: 'Interior' } };
+        const res = makeRes();
+
+        await createProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json.mock.calls[0][0].message).toBe('Internal Server Error');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getProductCategories
+// ─────────────────────────────────────────────────────────────────────────────
+describe('getProductCategories', () => {
+    const MOCK_LIST = [
+        { _id: new mongoose.Types.ObjectId(), name: 'Exterior' },
+        { _id: new mongoose.Types.ObjectId(), name: 'Interior' },
+    ];
+
+    test('200 with data array on success', async () => {
+        ProductCategory.find.mockReturnValue({ sort: jest.fn().mockResolvedValue(MOCK_LIST) });
+
+        const req = {};
+        const res = makeRes();
+
+        await getProductCategories(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        const body = res.json.mock.calls[0][0];
+        expect(body.data).toHaveLength(2);
+    });
+
+    test('results are sorted by name ascending', async () => {
+        const sortMock = jest.fn().mockResolvedValue(MOCK_LIST);
+        ProductCategory.find.mockReturnValue({ sort: sortMock });
+
+        await getProductCategories({}, makeRes());
+
+        expect(sortMock).toHaveBeenCalledWith({ name: 1 });
+    });
+
+    test('200 with empty array when no categories exist', async () => {
+        ProductCategory.find.mockReturnValue({ sort: jest.fn().mockResolvedValue([]) });
+
+        const res = makeRes();
+        await getProductCategories({}, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json.mock.calls[0][0].data).toHaveLength(0);
+    });
+
+    test('500 on DB error', async () => {
+        ProductCategory.find.mockImplementation(() => { throw new Error('DB error'); });
+
+        const res = makeRes();
+        await getProductCategories({}, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json.mock.calls[0][0].message).toBe('Internal Server Error');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// updateProductCategory
+// ─────────────────────────────────────────────────────────────────────────────
+describe('updateProductCategory', () => {
+    test('200 with updated category on success', async () => {
+        ProductCategory.findOne.mockResolvedValue(null);
+        ProductCategory.findByIdAndUpdate.mockResolvedValue({ ...MOCK_CAT, name: 'Exterior' });
+
+        const req = { params: { id: CAT_ID.toString() }, body: { name: 'Exterior' } };
+        const res = makeRes();
+
+        await updateProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json.mock.calls[0][0].message).toMatch(/updated successfully/i);
+    });
+
+    test('400 when name is missing', async () => {
+        const req = { params: { id: CAT_ID.toString() }, body: {} };
+        const res = makeRes();
+
+        await updateProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(ProductCategory.findOne).not.toHaveBeenCalled();
+    });
+
+    test('400 when another category already has the same name', async () => {
+        ProductCategory.findOne.mockResolvedValue({ _id: new mongoose.Types.ObjectId(), name: 'Exterior' });
+
+        const req = { params: { id: CAT_ID.toString() }, body: { name: 'Exterior' } };
+        const res = makeRes();
+
+        await updateProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json.mock.calls[0][0].message).toMatch(/already exists/i);
+    });
+
+    test('duplicate check excludes the current document by _id', async () => {
+        ProductCategory.findOne.mockResolvedValue(null);
+        ProductCategory.findByIdAndUpdate.mockResolvedValue(MOCK_CAT);
+
+        const req = { params: { id: CAT_ID.toString() }, body: { name: 'Interior' } };
+        await updateProductCategory(req, makeRes());
+
+        expect(ProductCategory.findOne).toHaveBeenCalledWith({
+            name: 'Interior',
+            _id: { $ne: CAT_ID.toString() },
+        });
+    });
+
+    test('404 when category id does not exist', async () => {
+        ProductCategory.findOne.mockResolvedValue(null);
+        ProductCategory.findByIdAndUpdate.mockResolvedValue(null);
+
+        const req = { params: { id: CAT_ID.toString() }, body: { name: 'New Name' } };
+        const res = makeRes();
+
+        await updateProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json.mock.calls[0][0].message).toMatch(/not found/i);
+    });
+
+    test('500 on DB error', async () => {
+        ProductCategory.findOne.mockRejectedValue(new Error('DB error'));
+
+        const req = { params: { id: CAT_ID.toString() }, body: { name: 'Interior' } };
+        const res = makeRes();
+
+        await updateProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// deleteProductCategory
+// ─────────────────────────────────────────────────────────────────────────────
+describe('deleteProductCategory', () => {
+    test('200 with success message when category is deleted', async () => {
+        ProductCategory.findByIdAndDelete.mockResolvedValue(MOCK_CAT);
+
+        const req = { params: { id: CAT_ID.toString() } };
+        const res = makeRes();
+
+        await deleteProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json.mock.calls[0][0].message).toMatch(/deleted successfully/i);
+    });
+
+    test('deletes by the id from req.params', async () => {
+        ProductCategory.findByIdAndDelete.mockResolvedValue(MOCK_CAT);
+
+        const req = { params: { id: CAT_ID.toString() } };
+        await deleteProductCategory(req, makeRes());
+
+        expect(ProductCategory.findByIdAndDelete).toHaveBeenCalledWith(CAT_ID.toString());
+    });
+
+    test('404 when category does not exist', async () => {
+        ProductCategory.findByIdAndDelete.mockResolvedValue(null);
+
+        const req = { params: { id: CAT_ID.toString() } };
+        const res = makeRes();
+
+        await deleteProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json.mock.calls[0][0].message).toMatch(/not found/i);
+    });
+
+    test('500 on DB error', async () => {
+        ProductCategory.findByIdAndDelete.mockRejectedValue(new Error('DB error'));
+
+        const req = { params: { id: CAT_ID.toString() } };
+        const res = makeRes();
+
+        await deleteProductCategory(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+    });
+});

--- a/tests/controllers/productOffers.controller.test.js
+++ b/tests/controllers/productOffers.controller.test.js
@@ -321,10 +321,11 @@ describe('ProductOffersController', () => {
             });
         });
 
-        // ── Route scheme filtering (recent change) ────────────────────────────
-        describe('routeScheme filtering', () => {
+        // ── Product category filtering ─────────────────────────────────────────
+        describe('productCategory filtering', () => {
             const DEALER_ID = new mongoose.Types.ObjectId();
-            const SE_MOBILE = '9876500001';
+            const CAT_A = new mongoose.Types.ObjectId();
+            const CAT_B = new mongoose.Types.ObjectId();
 
             function wireFind(offers = []) {
                 productOffersModel.find.mockReturnValue({
@@ -343,79 +344,125 @@ describe('ProductOffersController', () => {
                 wireFind();
             });
 
-            test('SuperUser bypasses routeScheme filter — query has neither $or nor $and for routeScheme', async () => {
+            test('SuperUser sees all offers — no productCategory filter applied', async () => {
                 const req = {
                     body: { page: 1, limit: 10 },
-                    user: { _id: DEALER_ID, accountType: 'SuperUser', mobile: '9999999999' },
+                    user: { _id: DEALER_ID, accountType: 'SuperUser' },
                 };
                 const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
 
                 await searchProductOffers(req, res);
 
-                const queryArg = productOffersModel.find.mock.calls[0][0];
-                // The only clause should be offerAvailable:true — no routeScheme filter
-                expect(queryArg).not.toHaveProperty('$and');
-                // If there IS an $or it must not contain any routeScheme condition
-                if (queryArg['$or']) {
-                    const hasRouteFilter = queryArg['$or'].some(
-                        clause => clause.routeScheme !== undefined
-                    );
-                    expect(hasRouteFilter).toBe(false);
-                }
-                expect(queryArg.offerAvailable).toBe(true);
+                const query = productOffersModel.find.mock.calls[0][0];
+                // SuperUser query must not contain any productCategory filter
+                expect(query).not.toHaveProperty('productCategory');
+                const allClauses = [
+                    ...(query['$or'] || []),
+                    ...(query['$and'] || []).flatMap(c => c['$or'] || [c]),
+                ];
+                const hasCatFilter = allClauses.some(c => c.productCategory !== undefined);
+                expect(hasCatFilter).toBe(false);
+                expect(query.offerAvailable).toBe(true);
             });
 
-            test('Dealer gets routeScheme filter scoped to their salesExecutive mobile', async () => {
+            test('Dealer query uses $in filter with their productCategories', async () => {
                 const req = {
                     body: { page: 1, limit: 10 },
-                    user: { _id: DEALER_ID, accountType: 'Dealer', salesExecutive: SE_MOBILE },
+                    user: { _id: DEALER_ID, accountType: 'Dealer', productCategories: [CAT_A, CAT_B] },
                 };
                 const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
 
                 await searchProductOffers(req, res);
 
-                const queryArg = productOffersModel.find.mock.calls[0][0];
-                // Expect routeScheme clauses to be present (either via $or at top level or inside $and)
-                const flatClauses = queryArg['$or'] ||
-                    (queryArg['$and'] || []).flatMap(c => c['$or'] || []);
-                const routeClauses = flatClauses.filter(c => c.routeScheme !== undefined);
-                expect(routeClauses.length).toBeGreaterThan(0);
-                // One of the clauses must allow offers with SE_MOBILE
-                const hasMobileClause = routeClauses.some(c => c.routeScheme === SE_MOBILE);
-                expect(hasMobileClause).toBe(true);
+                const query = productOffersModel.find.mock.calls[0][0];
+                // Either directly on the query or nested inside $and
+                const catFilter =
+                    query.productCategory ||
+                    (query['$and'] || []).map(c => c.productCategory).find(Boolean);
+                expect(catFilter).toBeDefined();
+                expect(catFilter.$in).toEqual([CAT_A, CAT_B]);
             });
 
-            test('SalesExecutive gets routeScheme filter scoped to their own mobile', async () => {
+            test('Dealer with no productCategories gets an empty $in — sees no offers', async () => {
                 const req = {
                     body: { page: 1, limit: 10 },
-                    user: { _id: DEALER_ID, accountType: 'SalesExecutive', mobile: SE_MOBILE },
+                    user: { _id: DEALER_ID, accountType: 'Dealer', productCategories: [] },
                 };
-                // SalesExecutive path also calls UserModel.find — mock it
-                const UserModel = require('../../models/User');
-                jest.mock('../../models/User');
+                const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+                await searchProductOffers(req, res);
+
+                const query = productOffersModel.find.mock.calls[0][0];
+                const catFilter =
+                    query.productCategory ||
+                    (query['$and'] || []).map(c => c.productCategory).find(Boolean);
+                expect(catFilter).toBeDefined();
+                expect(catFilter.$in).toHaveLength(0);
+            });
+
+            test('Dealer with undefined productCategories falls back to empty $in', async () => {
+                const req = {
+                    body: { page: 1, limit: 10 },
+                    user: { _id: DEALER_ID, accountType: 'Dealer' },
+                };
+                const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+                await searchProductOffers(req, res);
+
+                const query = productOffersModel.find.mock.calls[0][0];
+                const catFilter =
+                    query.productCategory ||
+                    (query['$and'] || []).map(c => c.productCategory).find(Boolean);
+                expect(catFilter.$in).toEqual([]);
+            });
+
+            test('SalesExecutive sees only offers where productCategory is set (not null)', async () => {
                 UserModel.find = jest.fn().mockResolvedValue([]);
-
+                const req = {
+                    body: { page: 1, limit: 10 },
+                    user: { _id: DEALER_ID, accountType: 'SalesExecutive', mobile: '9876500001' },
+                };
                 const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
 
                 await searchProductOffers(req, res);
 
-                const queryArg = productOffersModel.find.mock.calls[0][0];
-                const flatClauses = queryArg['$or'] ||
-                    (queryArg['$and'] || []).flatMap(c => c['$or'] || []);
-                const hasMobileClause = flatClauses.some(c => c.routeScheme === SE_MOBILE);
-                expect(hasMobileClause).toBe(true);
+                const query = productOffersModel.find.mock.calls[0][0];
+                const catFilter =
+                    query.productCategory ||
+                    (query['$and'] || []).map(c => c.productCategory).find(Boolean);
+                expect(catFilter).toBeDefined();
+                expect(catFilter.$ne).toBe(null);
+                expect(catFilter.$exists).toBe(true);
+            });
+
+            test('Dealer category filter combines with search $or via $and', async () => {
+                const req = {
+                    body: { page: 1, limit: 10, searchQuery: 'paint' },
+                    user: { _id: DEALER_ID, accountType: 'Dealer', productCategories: [CAT_A] },
+                };
+                const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+                await searchProductOffers(req, res);
+
+                const query = productOffersModel.find.mock.calls[0][0];
+                // When searchQuery is present, clauses should be merged via $and
+                expect(query).toHaveProperty('$and');
+                const andClauses = query['$and'];
+                const hasCatClause = andClauses.some(c => c.productCategory && c.productCategory.$in);
+                expect(hasCatClause).toBe(true);
+                const hasSearchClause = andClauses.some(c => c['$or'] !== undefined);
+                expect(hasSearchClause).toBe(true);
             });
 
             test('sort argument is { createdAt: -1 }', async () => {
                 const req = {
                     body: { page: 1, limit: 10 },
-                    user: { _id: DEALER_ID, accountType: 'SuperUser', mobile: '9999999999' },
+                    user: { _id: DEALER_ID, accountType: 'SuperUser' },
                 };
                 const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
 
                 await searchProductOffers(req, res);
 
-                // The sort() call is chained on the find query — grab its argument
                 const findChain = productOffersModel.find.mock.results[0].value;
                 const sortArg = findChain.skip.mock.results[0].value
                     .limit.mock.results[0].value
@@ -550,6 +597,49 @@ describe('ProductOffersController', () => {
             await createProductOffer(req, res);
 
             expect(res.status).toHaveBeenCalledWith(201);
+        });
+
+        test('saves productCategory from request body', async () => {
+            const CAT_ID = new mongoose.Types.ObjectId();
+            const req = {
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferDescription: 'Test',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                    productCategory: CAT_ID.toString(),
+                }
+            };
+            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+            await createProductOffer(req, res);
+
+            expect(productOffersModel).toHaveBeenCalledWith(
+                expect.objectContaining({ productCategory: CAT_ID.toString() })
+            );
+        });
+
+        test('saves productCategory as null when not provided', async () => {
+            const req = {
+                body: {
+                    productOfferImage: VALID_IMAGE,
+                    productOfferDescription: 'Test',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                    // no productCategory
+                }
+            };
+            const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+            await createProductOffer(req, res);
+
+            expect(productOffersModel).toHaveBeenCalledWith(
+                expect.objectContaining({ productCategory: null })
+            );
         });
 
         test('returns 400 when offer with same description already exists', async () => {
@@ -720,6 +810,45 @@ describe('ProductOffersController', () => {
 
             expect(s3Mock.upload).not.toHaveBeenCalled();
             expect(s3Mock.deleteObject).not.toHaveBeenCalled();
+        });
+
+        test('passes productCategory to findByIdAndUpdate', async () => {
+            const CAT_ID = new mongoose.Types.ObjectId();
+            const req = {
+                params: { id: OFFER_ID },
+                body: {
+                    productOfferDescription: 'Updated',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                    productCategory: CAT_ID.toString(),
+                }
+            };
+
+            await updateProductOffer(req, makeRes());
+
+            const updateArg = productOffersModel.findByIdAndUpdate.mock.calls[0][1];
+            expect(updateArg).toHaveProperty('productCategory', CAT_ID.toString());
+        });
+
+        test('sets productCategory to null in findByIdAndUpdate when not provided', async () => {
+            const req = {
+                params: { id: OFFER_ID },
+                body: {
+                    productOfferDescription: 'Updated',
+                    productOfferStatus: 'Active',
+                    cashback: 5,
+                    redeemPoints: 10,
+                    price: VALID_PRICE,
+                    // no productCategory
+                }
+            };
+
+            await updateProductOffer(req, makeRes());
+
+            const updateArg = productOffersModel.findByIdAndUpdate.mock.calls[0][1];
+            expect(updateArg).toHaveProperty('productCategory', null);
         });
 
         test('skips thumbnail deletion when no previous thumbnailUrl exists', async () => {

--- a/tests/controllers/userController.test.js
+++ b/tests/controllers/userController.test.js
@@ -27,7 +27,7 @@ jest.mock('../../utils/logger', () => ({
 
 const mongoose = require('mongoose');
 const userModel = require('../../models/User');
-const { getAllDealers } = require('../../controllers/userController');
+const { getAllDealers, userUpdate } = require('../../controllers/userController');
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -163,5 +163,88 @@ describe('getAllDealers', () => {
         expect(res.status).toHaveBeenCalledWith(200);
         const body = res.json.mock.calls[0][0];
         expect(body.data).toHaveLength(0);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// userUpdate — productCategories whitelist
+// ─────────────────────────────────────────────────────────────────────────────
+describe('userUpdate — productCategories', () => {
+    const USER_ID = new mongoose.Types.ObjectId().toString();
+    const CAT_A   = new mongoose.Types.ObjectId();
+    const CAT_B   = new mongoose.Types.ObjectId();
+
+    // Minimal valid non-dealer body that passes all validation
+    function dealerBody(overrides = {}) {
+        return {
+            mobile: '9876500001',
+            name: 'Test Dealer',
+            accountType: 'Dealer',
+            primaryContactPerson: 'Contact',
+            primaryContactPersonMobile: '9876500002',
+            salesExecutive: '9876500003',
+            dealerCode: 'D001',
+            address: '123 Main St',
+            productCategories: [CAT_A, CAT_B],
+            ...overrides,
+        };
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // No duplicate mobile, no duplicate dealer code
+        userModel.findOne.mockResolvedValue(null);
+        userModel.updateOne.mockResolvedValue({ modifiedCount: 1 });
+    });
+
+    test('productCategories is included in the $set payload sent to updateOne', async () => {
+        const result = jest.fn();
+
+        await userUpdate(USER_ID, dealerBody(), result);
+
+        expect(result).toHaveBeenCalledWith(expect.objectContaining({ status: 200 }));
+        const setPayload = userModel.updateOne.mock.calls[0][1].$set;
+        expect(setPayload).toHaveProperty('productCategories');
+        expect(setPayload.productCategories).toEqual([CAT_A, CAT_B]);
+    });
+
+    test('empty productCategories array is preserved in $set (not stripped)', async () => {
+        const result = jest.fn();
+
+        await userUpdate(USER_ID, dealerBody({ productCategories: [] }), result);
+
+        const setPayload = userModel.updateOne.mock.calls[0][1].$set;
+        expect(setPayload.productCategories).toEqual([]);
+    });
+
+    test('productCategories is NOT present in $set when omitted from body', async () => {
+        const body = dealerBody();
+        delete body.productCategories;
+        const result = jest.fn();
+
+        await userUpdate(USER_ID, body, result);
+
+        const setPayload = userModel.updateOne.mock.calls[0][1].$set;
+        expect(setPayload).not.toHaveProperty('productCategories');
+    });
+
+    test('updateOne is called with the correct user _id filter', async () => {
+        const result = jest.fn();
+
+        await userUpdate(USER_ID, dealerBody(), result);
+
+        const filter = userModel.updateOne.mock.calls[0][0];
+        expect(filter._id.toString()).toBe(USER_ID);
+    });
+
+    test('400 with errors array when mobile is missing', async () => {
+        const body = dealerBody({ mobile: '' });
+        const result = jest.fn();
+
+        await userUpdate(USER_ID, body, result);
+
+        expect(result).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+        expect(result.mock.calls[0][0].errors).toContain('Enter mobile number');
+        expect(userModel.updateOne).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
…iltering

Replaces the routeScheme (SE-mobile) filter for product offer visibility with a proper Product Categories master entity:

- New ProductCategory model, controller, and routes (full CRUD, ADMIN-only write, authenticated read)
- Dealers tagged with [productCategories] (ObjectId refs); mandatory for Dealer accountType, optional otherwise
- Product offers tagged with a single productCategory (ObjectId ref); null offers are hidden from all non-SuperUser accounts
- searchProductOffers: Dealer sees $in-matched offers, SalesExecutive sees any offer with a category set, SuperUser sees everything
- USER_ALLOWED_CREATE_FIELDS whitelist expanded to include productCategories so dealer saves are no longer silently stripped
- Startup index cleanup in database/mongoose.js to drop stale categoryId_1 index left over from an earlier schema iteration
- 18 new tests for productCategoryController; productOffers and userController test suites updated with category-aware assertions
- Fixed 2 pre-existing failures in ordersController tests (SE order requests were missing entityId/warehouseId/branchId added in the Focus8 feature)
- AGENTS.md updated with full changelog