### PR TITLE
chore(express): raise bodyParser JSON limit to 8mb for image uploads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ This Express/Jest backend powers Aultra Paints services. Use the guidance below 
 - Configure secrets via `.env` (never commit it); document new variables in your PR description so ops can update their environments.
 - Update the `config/express.js` CORS whitelist when onboarding new clients, and adjust `middleware/passport.js` for auth tweaks.
 - Validate and sanitize user inputs at controllers/services, and favor parameterized queries or ORM helpers when touching raw SQL.
+- **JSON body limit is `8mb`** (set in `config/express.js`). Image uploads — product offers, product catalog items, reward schemes — ship as base64 data URIs inside JSON, so this ceiling caps the effective upload size at ~5 MB of original-photo bytes after base64 inflation (~33%). Keep the frontend's compressImage `targetBytes` aligned with any change to this limit.
 
 ## Changes (as of 2026-04-26)
 

--- a/config/express.js
+++ b/config/express.js
@@ -40,8 +40,12 @@ var distDir = '../../dist/';
 //     res.sendFile(path.join(__dirname, '../../dist/index.html'));
 // });
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+// 8 MB ceiling for JSON bodies covers a ~5 MB user-uploaded image after
+// base64 inflation (~33%) plus the rest of the JSON request fields. Image
+// uploads (product offers, product catalog items, reward schemes) ship as
+// base64 data URIs inside JSON, so the body-parser limit governs them.
+app.use(bodyParser.json({ limit: '8mb' }));
+app.use(bodyParser.urlencoded({ limit: '8mb', extended: true }));
 
 app.use(cookieParser());
 app.use(compress());


### PR DESCRIPTION
## Summary
Raises the Express body-parser JSON / urlencoded limit from the default 100 KB to **8 MB** so the product-offer / product-catalog / reward-scheme image upload flows can accept real photos.

These features ship their images as base64 data URIs inside the JSON request body. With the old limit, anything over a tiny PNG tripped Express, which silently dropped the connection — the React client saw a generic 'Failed to fetch' instead of a clean 413.

8 MB gives ~6 MB of base64 image headroom (≈ 5 MB original photo after ~33 % base64 inflation) plus ~2 MB for the rest of the JSON envelope.

## Coupling
The frontend's `compressImage` utility was retuned to a matching 6 MB target so typical phone photos now pass through largely uncompressed. `AGENTS.md` in both repos now documents the front/back contract on this limit — if either side changes, sync the other.

## Test plan
- [x] Local Express boot — limit takes effect.
- [ ] Upload a 4 MB image via Product Offers edit → save succeeds, image visible.
- [ ] Upload a 10 MB image → backend returns 413; frontend surfaces the friendly 'Image is too large for the server' message rather than 'Failed to fetch'.
- [ ] Smaller payloads (non-image endpoints) unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>