### PR TITLE
feat(deals): add Deals resource (admin CRUD + mobile active endpoint)

### DIFF
--- a/controllers/brandController.js
+++ b/controllers/brandController.js
@@ -3,7 +3,7 @@ const { escapeRegex, clampLimit, clampPage } = require('../utils/validators');
 
 // Create a new brand
 const createBrand = async (req, res) => {
-  const { name } = req.body;
+  const { name, description } = req.body;
 
   try {
     const existingBrand = await Brand.findOne({ name });
@@ -12,7 +12,7 @@ const createBrand = async (req, res) => {
       return res.status(400).json({ error: 'This brand name already exists.' });
     }
 
-    const newBrand = new Brand({ name });
+    const newBrand = new Brand({ name, description: description ?? '' });
     await newBrand.save();
     res.status(201).json(newBrand);
 
@@ -83,7 +83,7 @@ const getBrandByName = async (req, res) => {
 // Update brand by ID
 const updateBrand = async (req, res) => {
   const { id } = req.params;
-  const { name } = req.body;
+  const { name, description } = req.body;
 
   try {
     const brand = await Brand.findById(id);
@@ -96,11 +96,11 @@ const updateBrand = async (req, res) => {
       return res.status(400).json({ error: 'This brand name already exists.' });
     }
 
-    if (brand.name === name) {
-      return res.status(200).json(brand);
-    }
-
-    const updatedBrand = await Brand.findByIdAndUpdate(id, { name }, { new: true });
+    const updatedBrand = await Brand.findByIdAndUpdate(
+      id,
+      { name, description: description ?? brand.description ?? '' },
+      { new: true },
+    );
 
     if (!updatedBrand) {
       return res.status(404).json({ error: 'Brand not found' });

--- a/controllers/deals.controller.js
+++ b/controllers/deals.controller.js
@@ -3,12 +3,27 @@ const s3 = require('../config/aws');
 const { decodeBase64Image } = require('../services/utils.service');
 const logger = require('../utils/logger');
 const UserModel = require('../models/User');
+const mongoose = require('mongoose');
 
 const BUCKET = process.env.AWS_BUCKET_DEALS;
+if (!BUCKET) {
+    logger.warn('AWS_BUCKET_DEALS is not set; deal image upload/delete will fail at runtime.');
+}
+
+function buildS3UploadParams(dealId, imageData) {
+    return {
+        Bucket: BUCKET,
+        Key: `${dealId}.png`,
+        Body: imageData.data,
+        ContentType: imageData.type,
+        ACL: 'public-read',
+    };
+}
 
 // POST /api/deals — admin only.
 // Body: { title, description?, expirationDate, active?, category, dealImage (data URI) }
 exports.createDeal = async (req, res) => {
+    let savedDeal;
     try {
         const { title, description, expirationDate, active, category, dealImage } = req.body;
 
@@ -19,7 +34,12 @@ exports.createDeal = async (req, res) => {
             return res.status(400).json({ message: 'Image is required' });
         }
 
-        const imageData = await decodeBase64Image(dealImage);
+        let imageData;
+        try {
+            imageData = await decodeBase64Image(dealImage);
+        } catch (_) {
+            imageData = new Error('Invalid image data');
+        }
         if (imageData instanceof Error) {
             return res.status(400).json({ message: 'Invalid image data' });
         }
@@ -34,22 +54,18 @@ exports.createDeal = async (req, res) => {
             dealImageUrl: 'pending', // overwritten right after upload
             createdBy: req.user && req.user.mobile,
         });
-        const savedDeal = await deal.save();
+        savedDeal = await deal.save();
 
-        const params = {
-            Bucket: BUCKET,
-            Key: `${savedDeal._id}.png`,
-            Body: imageData.data,
-            ContentType: imageData.type,
-            ACL: 'public-read',
-        };
-        const data = await s3.upload(params).promise();
+        const data = await s3.upload(buildS3UploadParams(savedDeal._id, imageData)).promise();
 
         savedDeal.dealImageUrl = data.Location;
         await savedDeal.save();
 
         return res.status(201).json(savedDeal);
     } catch (error) {
+        if (savedDeal && savedDeal._id) {
+            await Deal.findByIdAndDelete(savedDeal._id).catch(() => {});
+        }
         logger.error('createDeal failed', { error: error.message });
         return res.status(500).json({ message: error.message });
     }
@@ -59,8 +75,8 @@ exports.createDeal = async (req, res) => {
 // Query: ?page=1&limit=20&active=true&category=<id>&search=foo
 exports.getDeals = async (req, res) => {
     try {
-        const page = parseInt(req.query.page || 1, 10);
-        const limit = parseInt(req.query.limit || 20, 10);
+        const page = Math.max(1, parseInt(req.query.page || 1, 10));
+        const limit = Math.max(1, parseInt(req.query.limit || 20, 10));
         const skip = (page - 1) * limit;
 
         const filter = {};
@@ -97,6 +113,9 @@ exports.getDeals = async (req, res) => {
 
 // GET /api/deals/:id — admin only.
 exports.getDealById = async (req, res) => {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+        return res.status(400).json({ message: 'Invalid deal id' });
+    }
     try {
         const deal = await Deal.findById(req.params.id).populate('category', 'categoryName');
         if (!deal) return res.status(404).json({ message: 'Deal not found' });
@@ -110,6 +129,9 @@ exports.getDealById = async (req, res) => {
 // PUT /api/deals/:id — admin only.
 // Body: any subset of { title, description, expirationDate, active, category, dealImage (data URI) }
 exports.updateDeal = async (req, res) => {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+        return res.status(400).json({ message: 'Invalid deal id' });
+    }
     try {
         const existing = await Deal.findById(req.params.id);
         if (!existing) return res.status(404).json({ message: 'Deal not found' });
@@ -123,18 +145,16 @@ exports.updateDeal = async (req, res) => {
         if (req.user && req.user.mobile) updates.updatedBy = req.user.mobile;
 
         if (req.body.dealImage) {
-            const imageData = await decodeBase64Image(req.body.dealImage);
+            let imageData;
+            try {
+                imageData = await decodeBase64Image(req.body.dealImage);
+            } catch (_) {
+                imageData = new Error('Invalid image data');
+            }
             if (imageData instanceof Error) {
                 return res.status(400).json({ message: 'Invalid image data' });
             }
-            const params = {
-                Bucket: BUCKET,
-                Key: `${existing._id}.png`,
-                Body: imageData.data,
-                ContentType: imageData.type,
-                ACL: 'public-read',
-            };
-            const data = await s3.upload(params).promise();
+            const data = await s3.upload(buildS3UploadParams(existing._id, imageData)).promise();
             updates.dealImageUrl = data.Location;
         }
 
@@ -149,6 +169,9 @@ exports.updateDeal = async (req, res) => {
 
 // DELETE /api/deals/:id — admin only.
 exports.deleteDeal = async (req, res) => {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+        return res.status(400).json({ message: 'Invalid deal id' });
+    }
     try {
         const deal = await Deal.findById(req.params.id);
         if (!deal) return res.status(404).json({ message: 'Deal not found' });

--- a/controllers/deals.controller.js
+++ b/controllers/deals.controller.js
@@ -1,0 +1,198 @@
+const Deal = require('../models/deals.model');
+const s3 = require('../config/aws');
+const { decodeBase64Image } = require('../services/utils.service');
+const logger = require('../utils/logger');
+const UserModel = require('../models/User');
+
+const BUCKET = process.env.AWS_BUCKET_DEALS;
+
+// POST /api/deals — admin only.
+// Body: { title, description?, expirationDate, active?, category, dealImage (data URI) }
+exports.createDeal = async (req, res) => {
+    try {
+        const { title, description, expirationDate, active, category, dealImage } = req.body;
+
+        if (!title || !expirationDate || !category) {
+            return res.status(400).json({ message: 'title, expirationDate and category are required' });
+        }
+        if (!dealImage) {
+            return res.status(400).json({ message: 'Image is required' });
+        }
+
+        const imageData = await decodeBase64Image(dealImage);
+        if (imageData instanceof Error) {
+            return res.status(400).json({ message: 'Invalid image data' });
+        }
+
+        // Save the doc first so we have an _id for the S3 key.
+        const deal = new Deal({
+            title,
+            description: description || undefined,
+            expirationDate,
+            active: active !== undefined ? !!active : true,
+            category,
+            dealImageUrl: 'pending', // overwritten right after upload
+            createdBy: req.user && req.user.mobile,
+        });
+        const savedDeal = await deal.save();
+
+        const params = {
+            Bucket: BUCKET,
+            Key: `${savedDeal._id}.png`,
+            Body: imageData.data,
+            ContentType: imageData.type,
+            ACL: 'public-read',
+        };
+        const data = await s3.upload(params).promise();
+
+        savedDeal.dealImageUrl = data.Location;
+        await savedDeal.save();
+
+        return res.status(201).json(savedDeal);
+    } catch (error) {
+        logger.error('createDeal failed', { error: error.message });
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+// GET /api/deals — admin only.
+// Query: ?page=1&limit=20&active=true&category=<id>&search=foo
+exports.getDeals = async (req, res) => {
+    try {
+        const page = parseInt(req.query.page || 1, 10);
+        const limit = parseInt(req.query.limit || 20, 10);
+        const skip = (page - 1) * limit;
+
+        const filter = {};
+        if (req.query.active !== undefined) {
+            filter.active = req.query.active === 'true';
+        }
+        if (req.query.category) {
+            filter.category = req.query.category;
+        }
+        if (req.query.search) {
+            const escaped = req.query.search.toString().trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            filter.$or = [
+                { title: { $regex: new RegExp(escaped, 'i') } },
+                { description: { $regex: new RegExp(escaped, 'i') } },
+            ];
+        }
+
+        const [data, total] = await Promise.all([
+            Deal.find(filter).populate('category', 'categoryName').skip(skip).limit(limit).sort({ createdAt: -1 }),
+            Deal.countDocuments(filter),
+        ]);
+
+        return res.status(200).json({
+            data,
+            total,
+            pages: Math.ceil(total / limit) || 1,
+            currentPage: page,
+        });
+    } catch (error) {
+        logger.error('getDeals failed', { error: error.message });
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+// GET /api/deals/:id — admin only.
+exports.getDealById = async (req, res) => {
+    try {
+        const deal = await Deal.findById(req.params.id).populate('category', 'categoryName');
+        if (!deal) return res.status(404).json({ message: 'Deal not found' });
+        return res.status(200).json(deal);
+    } catch (error) {
+        logger.error('getDealById failed', { error: error.message });
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+// PUT /api/deals/:id — admin only.
+// Body: any subset of { title, description, expirationDate, active, category, dealImage (data URI) }
+exports.updateDeal = async (req, res) => {
+    try {
+        const existing = await Deal.findById(req.params.id);
+        if (!existing) return res.status(404).json({ message: 'Deal not found' });
+
+        const updates = {};
+        if (req.body.title !== undefined) updates.title = req.body.title;
+        if (req.body.description !== undefined) updates.description = req.body.description;
+        if (req.body.expirationDate !== undefined) updates.expirationDate = req.body.expirationDate;
+        if (req.body.active !== undefined) updates.active = !!req.body.active;
+        if (req.body.category !== undefined) updates.category = req.body.category;
+        if (req.user && req.user.mobile) updates.updatedBy = req.user.mobile;
+
+        if (req.body.dealImage) {
+            const imageData = await decodeBase64Image(req.body.dealImage);
+            if (imageData instanceof Error) {
+                return res.status(400).json({ message: 'Invalid image data' });
+            }
+            const params = {
+                Bucket: BUCKET,
+                Key: `${existing._id}.png`,
+                Body: imageData.data,
+                ContentType: imageData.type,
+                ACL: 'public-read',
+            };
+            const data = await s3.upload(params).promise();
+            updates.dealImageUrl = data.Location;
+        }
+
+        const deal = await Deal.findByIdAndUpdate(req.params.id, updates, { new: true })
+            .populate('category', 'categoryName');
+        return res.status(200).json(deal);
+    } catch (error) {
+        logger.error('updateDeal failed', { error: error.message });
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+// DELETE /api/deals/:id — admin only.
+exports.deleteDeal = async (req, res) => {
+    try {
+        const deal = await Deal.findById(req.params.id);
+        if (!deal) return res.status(404).json({ message: 'Deal not found' });
+
+        // Best-effort S3 cleanup. Log on failure but proceed with the DB delete.
+        try {
+            await s3.deleteObject({ Bucket: BUCKET, Key: `${deal._id}.png` }).promise();
+        } catch (s3Err) {
+            logger.warn('deleteDeal: S3 object delete failed', { id: deal._id.toString(), error: s3Err.message });
+        }
+
+        await Deal.findByIdAndDelete(req.params.id);
+        return res.status(200).json({ message: 'Deal deleted successfully' });
+    } catch (error) {
+        logger.error('deleteDeal failed', { error: error.message });
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+// GET /api/deals/active — authenticated, any role.
+// Returns deals where active=true, expirationDate>=now, category in user.productCategories.
+exports.getActiveDealsForUser = async (req, res) => {
+    try {
+        // Re-fetch the user to get productCategories (JWT may not carry it).
+        const user = await UserModel.findById(req.user._id).select('productCategories').lean();
+        const categories = (user && user.productCategories) || [];
+
+        if (categories.length === 0) {
+            return res.status(200).json([]);
+        }
+
+        const now = new Date();
+        const deals = await Deal.find({
+            active: true,
+            expirationDate: { $gte: now },
+            category: { $in: categories },
+        })
+            .select('_id title dealImageUrl expirationDate updatedAt')
+            .sort({ createdAt: -1 })
+            .lean();
+
+        return res.status(200).json(deals);
+    } catch (error) {
+        logger.error('getActiveDealsForUser failed', { error: error.message });
+        return res.status(500).json({ message: error.message });
+    }
+};

--- a/controllers/ordersController.js
+++ b/controllers/ordersController.js
@@ -316,7 +316,7 @@ exports.getOrders = async (req, res) => {
         const { accountType } = user;
         const { page, limit, status, dealerCode, salesExecutiveMobile, branchId } = req.body;
 
-        const ALLOWED_STATUSES = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'PARTIALLY_DISPATCHED'];
+        const ALLOWED_STATUSES = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'PARTIALLY_DISPATCHED', 'MANUALLY_DISPATCHED'];
         if (status !== undefined && status !== null && status !== '') {
             if (!ALLOWED_STATUSES.includes(status)) {
                 return res.status(400).json({ success: false, message: 'Invalid status' });
@@ -367,10 +367,10 @@ exports.getOrders = async (req, res) => {
         }
 
         let query = {};
-        let populateOptions = {
-            path: 'createdBy',
-            select: 'name mobile accountType dealerCode'
-        };
+        let populateOptions = [
+            { path: 'createdBy', select: 'name mobile accountType dealerCode' },
+            { path: 'statusHistory.changedBy', select: 'name accountType' },
+        ];
         let orders;
         let totalOrders;
 
@@ -614,11 +614,15 @@ exports.getOrderDetails = async (req, res) => {
                 const idsChanged = dcInvoiceIds.slice().sort().join(',') !== existingIds;
                 order.focusDCInvoiceId = dcInvoiceIds;
 
-                // Persist status and/or DC invoice IDs if anything changed
-                if (derivedStatus !== order.status || idsChanged) {
-                    const updateDoc = { focusDCInvoiceId: dcInvoiceIds };
-                    if (derivedStatus !== order.status) {
-                        updateDoc.status = derivedStatus;
+                // Persist status and/or DC invoice IDs if anything changed.
+                // Never overwrite a manually-set status with a Focus8-derived one.
+                const manualStatuses = ['MANUALLY_DISPATCHED'];
+                const canSyncStatus = !manualStatuses.includes(order.status);
+                const statusChanged = canSyncStatus && derivedStatus !== order.status;
+                if (statusChanged || idsChanged) {
+                    const updateDoc = { $set: { focusDCInvoiceId: dcInvoiceIds } };
+                    if (statusChanged) {
+                        updateDoc.$set.status = derivedStatus;
                         updateDoc.$push = { statusHistory: { status: derivedStatus, changedAt: new Date() } };
                         order.status = derivedStatus;
                     }
@@ -671,7 +675,10 @@ exports.getOrderDealers = async (req, res) => {
 
 exports.updateOrderStatus = async (req, res) => {
     try {
-        const { orderId, isVerified, entityId, warehouseId, branchId, narration } = req.body;
+        const { orderId, isVerified, narration } = req.body;
+        const entityId = req.body.entityId != null ? Number(req.body.entityId) : null;
+        const warehouseId = req.body.warehouseId != null ? Number(req.body.warehouseId) : null;
+        const branchId = req.body.branchId != null ? Number(req.body.branchId) : null;
         const user = req.user;
 
         // Check if the user is a SalesExecutive
@@ -711,17 +718,21 @@ exports.updateOrderStatus = async (req, res) => {
         let updateData = {};
         if (isVerified === 1) {
             updateData = {
-                status: 'VERIFIED',
-                isVerified: true,
-                isRejected: false,
-                $push: { statusHistory: { status: 'VERIFIED', changedAt: new Date() } }
+                $set: {
+                    status: 'VERIFIED',
+                    isVerified: true,
+                    isRejected: false,
+                    ...(entityId != null && { entityId }),
+                    ...(warehouseId != null && { warehouseId }),
+                    ...(branchId != null && { branchId }),
+                    ...(narration && { narration }),
+                },
+                $push: { statusHistory: { status: 'VERIFIED', changedAt: new Date() } },
             };
         } else if (isVerified === 0) {
             updateData = {
-                status: 'REJECTED',
-                isVerified: false,
-                isRejected: true,
-                $push: { statusHistory: { status: 'REJECTED', changedAt: new Date() } }
+                $set: { status: 'REJECTED', isVerified: false, isRejected: true },
+                $push: { statusHistory: { status: 'REJECTED', changedAt: new Date() } },
             };
         } else {
             return res.status(400).json({

--- a/controllers/ordersController.js
+++ b/controllers/ordersController.js
@@ -8,7 +8,55 @@ const path = require('path');
 const fs = require('fs');
 const productOffersModel = require("../models/productOffers.model");
 const userModel = require("../models/User");
-const { pushOrderToFocus8, getSOMobileAppOrders, getDCInvoiceForOrder, getProductMaster } = require("../services/focus8Order.service");
+const { pushOrderToFocus8, getSOMobileAppOrders, getDCInvoiceForOrder, getProductMaster, getBranchMaster, getPriceBookData, getDealerAccountId } = require("../services/focus8Order.service");
+
+// ── Focus8 price helpers (mirrors productCatlogController) ────────────────
+const _orderF8Cache = { priceBook: { data: null, ts: 0 } };
+const F8_TTL = 10 * 60 * 1000;
+
+async function _cachedPriceBook() {
+    if (_orderF8Cache.priceBook.data && Date.now() - _orderF8Cache.priceBook.ts < F8_TTL) {
+        return _orderF8Cache.priceBook.data;
+    }
+    const data = await getPriceBookData();
+    _orderF8Cache.priceBook = { data, ts: Date.now() };
+    return data;
+}
+
+function _parseFocusDate(dateStr) {
+    if (!dateStr) return 0;
+    if (typeof dateStr === 'string' && dateStr.includes('/')) {
+        const parts = dateStr.split('/');
+        if (parts.length === 3) {
+            const date = new Date(`${parts[2]}-${parts[1]}-${parts[0]}T00:00:00Z`);
+            return Math.floor(date.getTime() / (1000 * 60 * 60 * 24));
+        }
+    }
+    if (!isNaN(dateStr)) return Number(dateStr);
+    return 0;
+}
+
+function _getEffectivePriceFromFocus(focusProductId, focusAccountId, priceBookRecords, fallbackPrice) {
+    if (!focusProductId || !priceBookRecords || priceBookRecords.length === 0) return fallbackPrice;
+    const today = Math.floor(Date.now() / (1000 * 60 * 60 * 24));
+    const findLatest = (accountId) => {
+        const matching = priceBookRecords.filter(r =>
+            Number(r.iProductId) === Number(focusProductId) &&
+            Number(r.iAccountId) === Number(accountId) &&
+            _parseFocusDate(r.iStartDate) <= today
+        );
+        if (!matching.length) return null;
+        matching.sort((a, b) => _parseFocusDate(b.iStartDate) - _parseFocusDate(a.iStartDate));
+        return Number(matching[0].fVal1) || null;
+    };
+    if (focusAccountId) {
+        const dealerPrice = findLatest(focusAccountId);
+        if (dealerPrice !== null) return dealerPrice;
+    }
+    const basePrice = findLatest(0);
+    return basePrice !== null ? basePrice : fallbackPrice;
+}
+// ─────────────────────────────────────────────────────────────────────────
 
 
 async function generateInvoicePdf(order, user) {
@@ -167,6 +215,24 @@ exports.createOrder = async (req, res) => {
             .select('focusProductId focusUnitId focusProductMapping productOfferDescription price offerAvailable');
         const offerMap = new Map(offers.map(o => [o._id.toString(), o]));
 
+        // For dealer accounts, resolve the dealer's Focus8 account ID and pricebook so we
+        // can apply the same 3-step price resolution the catalog uses (dealer-specific →
+        // iAccountId=0 base → stored fallback). This prevents mismatch for dealers with
+        // special Focus8 pricing.
+        let dealerFocusAccountId = null;
+        let priceBookRecords = [];
+        const orderingDealerCode = req.user.dealerCode;
+        if (orderingDealerCode) {
+            try {
+                [dealerFocusAccountId, priceBookRecords] = await Promise.all([
+                    getDealerAccountId(orderingDealerCode),
+                    _cachedPriceBook(),
+                ]);
+            } catch (err) {
+                logger.warn(`ORDER :: Could not fetch Focus8 prices for dealer ${orderingDealerCode}: ${err.message}`);
+            }
+        }
+
         for (const item of items) {
             if (!item._id || !offerMap.has(item._id.toString())) {
                 return res.status(400).json({
@@ -193,8 +259,20 @@ exports.createOrder = async (req, res) => {
                     message: `No price configured for ${offer.productOfferDescription} @ ${item.volume}`
                 });
             }
+
+            // For dealers, apply the same 3-step Focus8 resolution the catalog uses so the
+            // price the dealer saw matches the price the order is validated against.
+            let resolvedPrice = priceTier.price;
+            if (priceBookRecords.length > 0) {
+                const volumeMapping = offer.focusProductMapping?.find(m => m.volume === item.volume);
+                const focusPid = volumeMapping?.focusProductId ?? offer.focusProductId;
+                if (focusPid) {
+                    resolvedPrice = _getEffectivePriceFromFocus(focusPid, dealerFocusAccountId, priceBookRecords, priceTier.price);
+                }
+            }
+
             // Overwrite any client-supplied price with the server-side value.
-            item.productPrice = priceTier.price;
+            item.productPrice = resolvedPrice;
 
             // Resolve Focus 8 IDs.
             if (!item.focusProductId || !item.focusUnitId) {
@@ -314,17 +392,23 @@ exports.getOrders = async (req, res) => {
     try {
         const user = req.user;
         const { accountType } = user;
-        const { page, limit, status, dealerCode, salesExecutiveMobile } = req.body;
+        const { page, limit, status, dealerCode, salesExecutiveMobile, branchId } = req.body;
 
-        const ALLOWED_STATUSES = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'IN-PARCEL'];
+        const ALLOWED_STATUSES = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'PARTIALLY_DISPATCHED', 'MANUALLY_DISPATCHED'];
         if (status !== undefined && status !== null && status !== '') {
             if (!ALLOWED_STATUSES.includes(status)) {
                 return res.status(400).json({ success: false, message: 'Invalid status' });
             }
         }
 
+        if (branchId !== undefined && branchId !== null) {
+            if (typeof branchId !== 'number' || branchId <= 0) {
+                return res.status(400).json({ success: false, message: 'Invalid branchId' });
+            }
+        }
+
         // If the user is neither SuperUser nor Dealer, returning an empty array
-        if (!['SuperUser', 'Dealer', 'SalesExecutive'].includes(accountType)) {
+        if (!['SuperUser', 'Dealer', 'SalesExecutive', 'ProductionManager'].includes(accountType)) {
             return res.status(200).json({
                 success: true,
                 orders: [],
@@ -361,17 +445,20 @@ exports.getOrders = async (req, res) => {
         }
 
         let query = {};
-        let populateOptions = {
-            path: 'createdBy',
-            select: 'name mobile accountType dealerCode'
-        };
+        let populateOptions = [
+            { path: 'createdBy', select: 'name mobile accountType dealerCode' },
+            { path: 'statusHistory.changedBy', select: 'name accountType' },
+        ];
         let orders;
         let totalOrders;
 
         // If SuperUser, fetch all orders with user details
-        if (accountType === 'SuperUser') {
+        if (accountType === 'SuperUser' || accountType === 'ProductionManager') {
             if (status) {
                 query.status = status;
+            }
+            if (branchId !== undefined && branchId !== null) {
+                query.branchId = branchId;
             }
             if (dealerIdFromCode) {
                 query.$or = [
@@ -446,6 +533,9 @@ exports.getOrders = async (req, res) => {
             if (status) {
                 query.status = status;
             }
+            if (branchId !== undefined && branchId !== null) {
+                query.branchId = branchId;
+            }
             totalOrders = await orderModel.countDocuments(query);
             orders = await orderModel
                 .find(query)
@@ -468,6 +558,9 @@ exports.getOrders = async (req, res) => {
             query = { $or: [{ createdBy: user._id }, { dealerId: user._id }] };
             if (status) {
                 query.status = status;
+            }
+            if (branchId !== undefined && branchId !== null) {
+                query.branchId = branchId;
             }
             totalOrders = await orderModel.countDocuments(query);
             orders = await orderModel
@@ -521,6 +614,7 @@ exports.getOrderDetails = async (req, res) => {
             .findOne({ orderId })
             .populate({ path: 'createdBy', select: 'name mobile accountType dealerCode' })
             .populate({ path: 'dealerId', select: 'name dealerCode mobile' })
+            .populate({ path: 'statusHistory.changedBy', select: 'name accountType' })
             .lean();
 
         if (!order) {
@@ -577,7 +671,7 @@ exports.getOrderDetails = async (req, res) => {
                         itemStatus = 'DISPATCHED';
                         fullyDispatched++;
                     } else if (dcQty > 0) {
-                        itemStatus = 'IN-PARCEL';
+                        itemStatus = 'PARTIALLY_DISPATCHED';
                         partiallyDispatched++;
                     }
                     return { ...item, dispatchStatus: itemStatus, dispatchedQty: dcQty };
@@ -589,7 +683,7 @@ exports.getOrderDetails = async (req, res) => {
                 if (fullyDispatched === itemsWithStatus.length) {
                     derivedStatus = 'DISPATCHED';
                 } else if (fullyDispatched > 0 || partiallyDispatched > 0) {
-                    derivedStatus = 'IN-PARCEL';
+                    derivedStatus = 'PARTIALLY_DISPATCHED';
                 }
 
                 // Extract unique DC invoice IDs from fetched rows
@@ -598,11 +692,15 @@ exports.getOrderDetails = async (req, res) => {
                 const idsChanged = dcInvoiceIds.slice().sort().join(',') !== existingIds;
                 order.focusDCInvoiceId = dcInvoiceIds;
 
-                // Persist status and/or DC invoice IDs if anything changed
-                if (derivedStatus !== order.status || idsChanged) {
-                    const updateDoc = { focusDCInvoiceId: dcInvoiceIds };
-                    if (derivedStatus !== order.status) {
-                        updateDoc.status = derivedStatus;
+                // Persist status and/or DC invoice IDs if anything changed.
+                // Never overwrite a manually-set status with a Focus8-derived one.
+                const manualStatuses = ['MANUALLY_DISPATCHED'];
+                const canSyncStatus = !manualStatuses.includes(order.status);
+                const statusChanged = canSyncStatus && derivedStatus !== order.status;
+                if (statusChanged || idsChanged) {
+                    const updateDoc = { $set: { focusDCInvoiceId: dcInvoiceIds } };
+                    if (statusChanged) {
+                        updateDoc.$set.status = derivedStatus;
                         updateDoc.$push = { statusHistory: { status: derivedStatus, changedAt: new Date() } };
                         order.status = derivedStatus;
                     }
@@ -622,6 +720,37 @@ exports.getOrderDetails = async (req, res) => {
             order.focusData = [];
         }
 
+        // Enrich order items with product image URLs from productOffers
+        try {
+            const itemIds = order.items.map(i => i._id).filter(Boolean);
+            if (itemIds.length > 0) {
+                const offers = await productOffersModel
+                    .find({ _id: { $in: itemIds } })
+                    .select('productOfferThumbnailUrl productOfferImageUrl')
+                    .lean();
+                const imageMap = new Map(offers.map(o => [o._id.toString(), o]));
+                order.items = order.items.map(item => {
+                    const offer = imageMap.get(item._id.toString());
+                    return offer
+                        ? { ...item, productOfferThumbnailUrl: offer.productOfferThumbnailUrl, productOfferImageUrl: offer.productOfferImageUrl }
+                        : item;
+                });
+            }
+        } catch (err) {
+            logger.warn(`Failed to enrich order items with image URLs for order ${orderId}`, { message: err.message });
+        }
+
+        // Resolve branchId -> branchName for display
+        if (order.branchId != null) {
+            try {
+                const branches = await getBranchMaster();
+                const match = branches.find(b => b.iMasterId === order.branchId);
+                if (match) order.branchName = match.sName;
+            } catch (err) {
+                logger.warn(`FOCUS8 :: Failed to resolve branchName for order ${orderId}`, { message: err.message });
+            }
+        }
+
         return res.status(200).json({ success: true, order });
     } catch (error) {
         logger.error('Error fetching order details', error);
@@ -632,9 +761,7 @@ exports.getOrderDetails = async (req, res) => {
 exports.getOrderDealers = async (req, res) => {
     try {
         const { accountType, mobile } = req.user;
-        if (!['SuperUser', 'SalesExecutive'].includes(accountType)) {
-            return res.status(403).json({ success: false, message: 'Forbidden' });
-        }
+
         const filter = { accountType: 'Dealer', status: 'active' };
         if (accountType === 'SalesExecutive') {
             const juniorSEs = await userModel.find(
@@ -657,7 +784,10 @@ exports.getOrderDealers = async (req, res) => {
 
 exports.updateOrderStatus = async (req, res) => {
     try {
-        const { orderId, isVerified, entityId, warehouseId, branchId, narration } = req.body;
+        const { orderId, isVerified, narration } = req.body;
+        const entityId = req.body.entityId != null ? Number(req.body.entityId) : null;
+        const warehouseId = req.body.warehouseId != null ? Number(req.body.warehouseId) : null;
+        const branchId = req.body.branchId != null ? Number(req.body.branchId) : null;
         const user = req.user;
 
         // Check if the user is a SalesExecutive
@@ -697,17 +827,21 @@ exports.updateOrderStatus = async (req, res) => {
         let updateData = {};
         if (isVerified === 1) {
             updateData = {
-                status: 'VERIFIED',
-                isVerified: true,
-                isRejected: false,
-                $push: { statusHistory: { status: 'VERIFIED', changedAt: new Date() } }
+                $set: {
+                    status: 'VERIFIED',
+                    isVerified: true,
+                    isRejected: false,
+                    ...(entityId != null && { entityId }),
+                    ...(warehouseId != null && { warehouseId }),
+                    ...(branchId != null && { branchId }),
+                    ...(narration && { narration }),
+                },
+                $push: { statusHistory: { status: 'VERIFIED', changedAt: new Date() } },
             };
         } else if (isVerified === 0) {
             updateData = {
-                status: 'REJECTED',
-                isVerified: false,
-                isRejected: true,
-                $push: { statusHistory: { status: 'REJECTED', changedAt: new Date() } }
+                $set: { status: 'REJECTED', isVerified: false, isRejected: true },
+                $push: { statusHistory: { status: 'REJECTED', changedAt: new Date() } },
             };
         } else {
             return res.status(400).json({
@@ -749,6 +883,63 @@ exports.updateOrderStatus = async (req, res) => {
 
     } catch (error) {
         logger.error('Error updating order status: ', error);
+        return res.status(500).json({
+            success: false,
+            message: 'Error updating order status',
+            error: error.message
+        });
+    }
+};
+
+exports.updateOrderStatusManual = async (req, res) => {
+    try {
+        const { orderId, status, remarks } = req.body;
+        const user = req.user;
+
+        if (!orderId || !status) {
+            return res.status(400).json({ success: false, message: 'orderId and status are required' });
+        }
+
+        const MANUAL_ALLOWED_STATUSES = ['DISPATCHED', 'MANUALLY_DISPATCHED'];
+        if (!MANUAL_ALLOWED_STATUSES.includes(status)) {
+            return res.status(400).json({ success: false, message: 'Invalid status for manual update' });
+        }
+
+        const order = await orderModel.findOne({ orderId });
+        if (!order) {
+            return res.status(404).json({ success: false, message: 'Order not found' });
+        }
+
+        const update = {
+            $set: { status },
+            $push: {
+                statusHistory: {
+                    status,
+                    changedAt: new Date(),
+                    changedBy: user._id,
+                    remarks: remarks || null
+                }
+            }
+        };
+
+        const updatedOrder = await orderModel.findOneAndUpdate(
+            { orderId },
+            update,
+            { new: true }
+        ).populate({
+            path: 'statusHistory.changedBy',
+            select: 'name accountType'
+        });
+
+        logger.info(`Order status updated manually`, { orderId, status, remarks, updatedBy: user.name });
+
+        res.json({
+            success: true,
+            message: `Order status updated to ${status}`,
+            order: updatedOrder
+        });
+    } catch (error) {
+        logger.error('Error updating order status manually: ', error);
         return res.status(500).json({
             success: false,
             message: 'Error updating order status',

--- a/controllers/ordersController.js
+++ b/controllers/ordersController.js
@@ -314,17 +314,23 @@ exports.getOrders = async (req, res) => {
     try {
         const user = req.user;
         const { accountType } = user;
-        const { page, limit, status, dealerCode, salesExecutiveMobile } = req.body;
+        const { page, limit, status, dealerCode, salesExecutiveMobile, branchId } = req.body;
 
-        const ALLOWED_STATUSES = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'IN-PARCEL'];
+        const ALLOWED_STATUSES = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'PARTIALLY_DISPATCHED'];
         if (status !== undefined && status !== null && status !== '') {
             if (!ALLOWED_STATUSES.includes(status)) {
                 return res.status(400).json({ success: false, message: 'Invalid status' });
             }
         }
 
+        if (branchId !== undefined && branchId !== null) {
+            if (typeof branchId !== 'number' || branchId <= 0) {
+                return res.status(400).json({ success: false, message: 'Invalid branchId' });
+            }
+        }
+
         // If the user is neither SuperUser nor Dealer, returning an empty array
-        if (!['SuperUser', 'Dealer', 'SalesExecutive'].includes(accountType)) {
+        if (!['SuperUser', 'Dealer', 'SalesExecutive', 'ProductionManager'].includes(accountType)) {
             return res.status(200).json({
                 success: true,
                 orders: [],
@@ -369,9 +375,12 @@ exports.getOrders = async (req, res) => {
         let totalOrders;
 
         // If SuperUser, fetch all orders with user details
-        if (accountType === 'SuperUser') {
+        if (accountType === 'SuperUser' || accountType === 'ProductionManager') {
             if (status) {
                 query.status = status;
+            }
+            if (branchId !== undefined && branchId !== null) {
+                query.branchId = branchId;
             }
             if (dealerIdFromCode) {
                 query.$or = [
@@ -446,6 +455,9 @@ exports.getOrders = async (req, res) => {
             if (status) {
                 query.status = status;
             }
+            if (branchId !== undefined && branchId !== null) {
+                query.branchId = branchId;
+            }
             totalOrders = await orderModel.countDocuments(query);
             orders = await orderModel
                 .find(query)
@@ -468,6 +480,9 @@ exports.getOrders = async (req, res) => {
             query = { $or: [{ createdBy: user._id }, { dealerId: user._id }] };
             if (status) {
                 query.status = status;
+            }
+            if (branchId !== undefined && branchId !== null) {
+                query.branchId = branchId;
             }
             totalOrders = await orderModel.countDocuments(query);
             orders = await orderModel
@@ -521,6 +536,7 @@ exports.getOrderDetails = async (req, res) => {
             .findOne({ orderId })
             .populate({ path: 'createdBy', select: 'name mobile accountType dealerCode' })
             .populate({ path: 'dealerId', select: 'name dealerCode mobile' })
+            .populate({ path: 'statusHistory.changedBy', select: 'name accountType' })
             .lean();
 
         if (!order) {
@@ -577,7 +593,7 @@ exports.getOrderDetails = async (req, res) => {
                         itemStatus = 'DISPATCHED';
                         fullyDispatched++;
                     } else if (dcQty > 0) {
-                        itemStatus = 'IN-PARCEL';
+                        itemStatus = 'PARTIALLY_DISPATCHED';
                         partiallyDispatched++;
                     }
                     return { ...item, dispatchStatus: itemStatus, dispatchedQty: dcQty };
@@ -589,7 +605,7 @@ exports.getOrderDetails = async (req, res) => {
                 if (fullyDispatched === itemsWithStatus.length) {
                     derivedStatus = 'DISPATCHED';
                 } else if (fullyDispatched > 0 || partiallyDispatched > 0) {
-                    derivedStatus = 'IN-PARCEL';
+                    derivedStatus = 'PARTIALLY_DISPATCHED';
                 }
 
                 // Extract unique DC invoice IDs from fetched rows
@@ -632,9 +648,7 @@ exports.getOrderDetails = async (req, res) => {
 exports.getOrderDealers = async (req, res) => {
     try {
         const { accountType, mobile } = req.user;
-        if (!['SuperUser', 'SalesExecutive'].includes(accountType)) {
-            return res.status(403).json({ success: false, message: 'Forbidden' });
-        }
+
         const filter = { accountType: 'Dealer', status: 'active' };
         if (accountType === 'SalesExecutive') {
             const juniorSEs = await userModel.find(
@@ -749,6 +763,63 @@ exports.updateOrderStatus = async (req, res) => {
 
     } catch (error) {
         logger.error('Error updating order status: ', error);
+        return res.status(500).json({
+            success: false,
+            message: 'Error updating order status',
+            error: error.message
+        });
+    }
+};
+
+exports.updateOrderStatusManual = async (req, res) => {
+    try {
+        const { orderId, status, remarks } = req.body;
+        const user = req.user;
+
+        if (!orderId || !status) {
+            return res.status(400).json({ success: false, message: 'orderId and status are required' });
+        }
+
+        const MANUAL_ALLOWED_STATUSES = ['DISPATCHED', 'MANUALLY_DISPATCHED'];
+        if (!MANUAL_ALLOWED_STATUSES.includes(status)) {
+            return res.status(400).json({ success: false, message: 'Invalid status for manual update' });
+        }
+
+        const order = await orderModel.findOne({ orderId });
+        if (!order) {
+            return res.status(404).json({ success: false, message: 'Order not found' });
+        }
+
+        const update = {
+            $set: { status },
+            $push: {
+                statusHistory: {
+                    status,
+                    changedAt: new Date(),
+                    changedBy: user._id,
+                    remarks: remarks || null
+                }
+            }
+        };
+
+        const updatedOrder = await orderModel.findOneAndUpdate(
+            { orderId },
+            update,
+            { new: true }
+        ).populate({
+            path: 'statusHistory.changedBy',
+            select: 'name accountType'
+        });
+
+        logger.info(`Order status updated manually`, { orderId, status, remarks, updatedBy: user.name });
+
+        res.json({
+            success: true,
+            message: `Order status updated to ${status}`,
+            order: updatedOrder
+        });
+    } catch (error) {
+        logger.error('Error updating order status manually: ', error);
         return res.status(500).json({
             success: false,
             message: 'Error updating order status',

--- a/controllers/productCategoryController.js
+++ b/controllers/productCategoryController.js
@@ -2,7 +2,7 @@ const ProductCategory = require('../models/ProductCategory');
 
 exports.createProductCategory = async (req, res) => {
     try {
-        const { name } = req.body;
+        const { name, description } = req.body;
         if (!name || !name.trim()) {
             return res.status(400).json({ message: 'Category name is required.' });
         }
@@ -10,7 +10,7 @@ exports.createProductCategory = async (req, res) => {
         if (existing) {
             return res.status(400).json({ message: 'Category name already exists.' });
         }
-        const category = new ProductCategory({ name: name.trim() });
+        const category = new ProductCategory({ name: name.trim(), description: description ?? '' });
         await category.save();
         return res.status(201).json({ message: 'Product category created successfully', data: category });
     } catch (err) {
@@ -29,7 +29,7 @@ exports.getProductCategories = async (req, res) => {
 
 exports.updateProductCategory = async (req, res) => {
     try {
-        const { name } = req.body;
+        const { name, description } = req.body;
         if (!name || !name.trim()) {
             return res.status(400).json({ message: 'Category name is required.' });
         }
@@ -42,7 +42,7 @@ exports.updateProductCategory = async (req, res) => {
         }
         const category = await ProductCategory.findByIdAndUpdate(
             req.params.id,
-            { name: name.trim() },
+            { name: name.trim(), ...(description !== undefined && { description }) },
             { new: true }
         );
         if (!category) {

--- a/controllers/productCatlogController.js
+++ b/controllers/productCatlogController.js
@@ -35,163 +35,105 @@ async function _cachedDealerAccountId(dealerCode) {
 
 // Create Product Catlog
 exports.createProductCatlog = async (req, res) => {
-  let { productDescription, productStatus, price, focusProductId, focusUnitId = 1, focusProductMapping, productCategory } = req.body;
+  let { productDescription, productStatus, focusProductId, focusUnitId = 1, focusProductMapping, productCategory } = req.body;
 
   if (!req.body.productImage) {
-    return res.status(400).json({ message: 'Product  image is required' });
+    return res.status(400).json({ message: 'Product image is required' });
   }
 
-  // Decode the base64 image
   const imageData = await decodeBase64Image(req.body.productImage);
   if (imageData instanceof Error) {
     return res.status(400).json({ message: 'Invalid image data' });
   }
 
-  // Parse and validate price field
-  let parsedPrice = [];
+  // focusProductMapping is required — prices are seeded from Focus8, not entered manually
+  if (!focusProductMapping) {
+    return res.status(400).json({ message: 'focusProductMapping is required' });
+  }
+
+  let parsedFocusMapping;
   try {
-    const priceData = typeof price === 'string' ? JSON.parse(price) : price;
-    if (typeof priceData !== 'object' || priceData === null) {
-      throw new Error('Price data must be an object');
+    const mappingData = typeof focusProductMapping === 'string'
+      ? JSON.parse(focusProductMapping)
+      : focusProductMapping;
+
+    if (!Array.isArray(mappingData) || mappingData.length === 0) {
+      throw new Error('focusProductMapping must be a non-empty array');
     }
 
-    // Transform the price data to match the schema
-    for (const [volume, priceEntries] of Object.entries(priceData)) {
-      if (!Array.isArray(priceEntries)) continue;
+    parsedFocusMapping = mappingData.map(m => {
+      if (!m.volume || !m.focusProductId) {
+        throw new Error('Each mapping must have volume and focusProductId');
+      }
+      return {
+        volume: m.volume,
+        focusProductId: Number(m.focusProductId),
+        focusUnitId: m.focusUnitId ? Number(m.focusUnitId) : 1,
+      };
+    });
 
-      priceEntries.forEach(entry => {
-        const [[refId, priceValue]] = Object.entries(entry);
-        if (refId && priceValue !== undefined) {
-          parsedPrice.push({
-            volume,
-            refId,
-            price: Number(priceValue)
-          });
-        }
-      });
-    }
-
-    if (parsedPrice.length === 0) {
-      throw new Error('No valid price entries found');
+    const volumeCounts = {};
+    parsedFocusMapping.forEach(m => { volumeCounts[m.volume] = (volumeCounts[m.volume] || 0) + 1; });
+    const duplicates = Object.keys(volumeCounts).filter(v => volumeCounts[v] > 1);
+    if (duplicates.length > 0) {
+      throw new Error(`Duplicate volumes in mapping: ${duplicates.join(', ')}`);
     }
   } catch (error) {
-    console.error('Error parsing price data:', error);
-    return res.status(400).json({ message: 'Invalid price format: ' + error.message });
+    return res.status(400).json({ message: 'Invalid focusProductMapping: ' + error.message });
   }
 
-  // Parse and validate focusProductMapping if provided
-  let parsedFocusMapping = null;
-  if (focusProductMapping) {
-    try {
-      const mappingData = typeof focusProductMapping === 'string' 
-        ? JSON.parse(focusProductMapping) 
-        : focusProductMapping;
-
-      if (!Array.isArray(mappingData)) {
-        throw new Error('focusProductMapping must be an array');
-      }
-
-      // Validate mapping structure
-      parsedFocusMapping = mappingData.map(mapping => {
-        if (!mapping.volume || !mapping.focusProductId) {
-          throw new Error('Each mapping must have volume and focusProductId');
-        }
-        return {
-          volume: mapping.volume,
-          focusProductId: Number(mapping.focusProductId),
-          focusUnitId: mapping.focusUnitId ? Number(mapping.focusUnitId) : 1
-        };
-      });
-
-      // Validate that all volumes in price have corresponding mapping
-      const priceVolumes = [...new Set(parsedPrice.map(p => p.volume))];
-      const mappingVolumes = parsedFocusMapping.map(m => m.volume);
-      const missingVolumes = priceVolumes.filter(v => !mappingVolumes.includes(v));
-      
-      if (missingVolumes.length > 0) {
-        throw new Error(`Missing focus product mapping for volumes: ${missingVolumes.join(', ')}`);
-      }
-
-      // Check for duplicate volumes in mapping
-      const volumeCounts = {};
-      mappingVolumes.forEach(v => {
-        volumeCounts[v] = (volumeCounts[v] || 0) + 1;
-      });
-      const duplicates = Object.keys(volumeCounts).filter(v => volumeCounts[v] > 1);
-      if (duplicates.length > 0) {
-        throw new Error(`Duplicate volumes in focus product mapping: ${duplicates.join(', ')}`);
-      }
-
-    } catch (error) {
-      console.error('Error parsing focus product mapping:', error);
-      return res.status(400).json({ message: 'Invalid focus product mapping: ' + error.message });
-    }
-  }
-
-  // Create the product catlog document
-  const productCatlog = new productOfferModel({
-    productOfferDescription: productDescription,
-    productOfferStatus: productStatus,
-    price: parsedPrice,
-    offerAvailable: false,
-    productCategory: productCategory || null,
-    focusProductId: focusProductId ? Number(focusProductId) : null,
-    focusUnitId: focusUnitId ? Number(focusUnitId) : null,
-    focusProductMapping: parsedFocusMapping || undefined
-  });
-
+  let savedProductCatlog;
   try {
-    const existingProductCatlog = await productOfferModel.findOne({ productOfferDescription: productDescription });
-    if (existingProductCatlog) {
-      return res.status(400).json({ message: 'Product catlog with the same description already exists' });
+    const existing = await productOfferModel.findOne({ productOfferDescription: productDescription });
+    if (existing) {
+      return res.status(400).json({ message: 'Product catalog with the same description already exists' });
     }
 
-    // Save the product catlog
-    let savedProductCatlog = await productCatlog.save();
-    const savedProductCatlogId = savedProductCatlog._id;
+    savedProductCatlog = await new productOfferModel({
+      productOfferDescription: productDescription,
+      productOfferStatus: productStatus,
+      price: [],
+      offerAvailable: false,
+      productCategory: productCategory || null,
+      focusProductId: focusProductId ? Number(focusProductId) : null,
+      focusUnitId: focusUnitId ? Number(focusUnitId) : null,
+      focusProductMapping: parsedFocusMapping,
+    }).save();
 
-    // Upload the image to AWS S3 if image data exists
     if (imageData) {
-      const params = {
+      const s3Data = await s3.upload({
         Bucket: process.env.AWS_BUCKET_PRODUCT_CATEGORY,
-        Key: `${savedProductCatlogId}.png`,
+        Key: `${savedProductCatlog._id}.png`,
         Body: imageData.data,
         ContentType: imageData.type,
         ACL: 'public-read',
-      };
-
-      const data = await s3.upload(params).promise();
+      }).promise();
       await productOfferModel.updateOne(
         { _id: savedProductCatlog._id },
-        { $set: { productOfferImageUrl: data.Location } }
+        { $set: { productOfferImageUrl: s3Data.Location } }
       );
-      savedProductCatlog.productOfferImageUrl = data.Location;
+      savedProductCatlog.productOfferImageUrl = s3Data.Location;
     }
 
-    await processProductCatlogPrices(savedProductCatlogId, parsedPrice);
+    await seedPricesFromFocus(savedProductCatlog);
 
     return res.status(201).json(savedProductCatlog);
   } catch (error) {
-    console.log(error);
-    if (error instanceof multer.MulterError) {
-      if (error.code === 'LIMIT_FILE_SIZE') {
-        return res.status(400).json({ error: 'File size exceeds the limit (4 MB)' });
-      }
-    } else {
-      return res.status(500).json({ message: error.message });
+    // Roll back the saved document if price seeding failed
+    if (savedProductCatlog?._id) {
+      await productOfferModel.findByIdAndDelete(savedProductCatlog._id).catch(() => {});
     }
+    console.log(error);
+    if (error instanceof multer.MulterError && error.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({ error: 'File size exceeds the limit (4 MB)' });
+    }
+    return res.status(502).json({ message: error.message });
   }
 };
 
 
-/**
- * Helper function to parse Focus8 date string
- * @param {string|number} dateStr - Date string in DD-MM-YYYY format or timestamp
- * @returns {number} Days since epoch
- */
 const parseFocusDate = (dateStr) => {
   if (!dateStr) return 0;
-  
   if (typeof dateStr === 'string' && dateStr.includes('-')) {
     const parts = dateStr.split('-');
     if (parts.length === 3) {
@@ -199,47 +141,64 @@ const parseFocusDate = (dateStr) => {
       return Math.floor(date.getTime() / (1000 * 60 * 60 * 24));
     }
   }
-  
   if (!isNaN(dateStr)) return Number(dateStr);
   return 0;
 };
 
-/**
- * Helper function to get the effective price from Focus8 pricebook
- * @param {number} focusProductId - The Focus8 product ID
- * @param {number} focusAccountId - The Focus8 account ID (iMasterId)
- * @param {Array} priceBookRecords - All pricebook records from Focus8
- * @param {number} catalogPrice - Fallback price from product catalog
- * @returns {number} The effective price
- */
-const getEffectivePriceFromFocus = (focusProductId, focusAccountId, priceBookRecords, catalogPrice) => {
-  if (!focusProductId || !focusAccountId || !priceBookRecords || priceBookRecords.length === 0) {
-    return catalogPrice;
-  }
-
-  const currentDate = Math.floor(Date.now() / 1000 / 60 / 60 / 24); // Days since epoch
-
-  // Filter records matching product and account
-  const matchingRecords = priceBookRecords.filter(record => 
-    Number(record.iProductId) === Number(focusProductId) && 
-    Number(record.iAccountId) === Number(focusAccountId) &&
-    parseFocusDate(record.iStartDate) <= currentDate // Only prices that are already effective
+// Returns the latest iAccountId=0 (universal) base price for a focus product.
+// Returns null when no matching record exists.
+const getBasePriceFromFocus = (focusProductId, priceBookRecords) => {
+  if (!focusProductId || !priceBookRecords || priceBookRecords.length === 0) return null;
+  const currentDate = Math.floor(Date.now() / 1000 / 60 / 60 / 24);
+  const records = priceBookRecords.filter(r =>
+    Number(r.iProductId) === Number(focusProductId) &&
+    Number(r.iAccountId) === 0 &&
+    parseFocusDate(r.iStartDate) <= currentDate
   );
+  if (!records.length) return null;
+  records.sort((a, b) => parseFocusDate(b.iStartDate) - parseFocusDate(a.iStartDate));
+  return Number(records[0].fVal1) || null;
+};
 
-  if (matchingRecords.length === 0) {
+// 3-step price resolution:
+//   1. dealer-specific  (iAccountId === focusAccountId)
+//   2. universal base   (iAccountId === 0)
+//   3. stored catalog   (fallback when Focus8 unreachable)
+const getEffectivePriceFromFocus = (focusProductId, focusAccountId, priceBookRecords, catalogPrice) => {
+  if (!focusProductId || !priceBookRecords || priceBookRecords.length === 0) {
     return catalogPrice;
   }
 
-  // Sort by iStartDate descending (latest first)
-  matchingRecords.sort((a, b) => parseFocusDate(b.iStartDate) - parseFocusDate(a.iStartDate));
+  const currentDate = Math.floor(Date.now() / 1000 / 60 / 60 / 24);
 
-  // Return the latest price (fVal1)
-  const effectivePrice = Number(matchingRecords[0].fVal1);
-  
-  logger.info(`FOCUS8 :: Found custom price for product ${focusProductId}, account ${focusAccountId}: ${effectivePrice}`);
-  
-  return effectivePrice || catalogPrice;
+  const findLatest = (accountId) => {
+    const matching = priceBookRecords.filter(r =>
+      Number(r.iProductId) === Number(focusProductId) &&
+      Number(r.iAccountId) === Number(accountId) &&
+      parseFocusDate(r.iStartDate) <= currentDate
+    );
+    if (!matching.length) return null;
+    matching.sort((a, b) => parseFocusDate(b.iStartDate) - parseFocusDate(a.iStartDate));
+    return Number(matching[0].fVal1) || null;
+  };
+
+  if (focusAccountId) {
+    const dealerPrice = findLatest(focusAccountId);
+    if (dealerPrice !== null) {
+      logger.info(`FOCUS8 :: Dealer-specific price for product ${focusProductId}, account ${focusAccountId}: ${dealerPrice}`);
+      return dealerPrice;
+    }
+  }
+
+  const basePrice = findLatest(0);
+  if (basePrice !== null) {
+    logger.info(`FOCUS8 :: Base price (iAccountId=0) for product ${focusProductId}: ${basePrice}`);
+    return basePrice;
+  }
+
+  return catalogPrice;
 };
+
 
 
 const processProductCatlogPrices = async (productcatlogId, parsedPrices) => {
@@ -298,6 +257,40 @@ const processProductCatlogPrices = async (productcatlogId, parsedPrices) => {
       errorObj: JSON.stringify(error)
     });
   }
+};
+
+// Fetches the Focus8 pricebook, resolves iAccountId=0 base prices for every
+// volume in product.focusProductMapping, persists them to price[] and
+// rebuilds ProductPrice records for all dealers. Throws on Focus8 failure.
+const seedPricesFromFocus = async (product) => {
+  const mapping = product.focusProductMapping;
+  if (!mapping || mapping.length === 0) {
+    throw new Error('No focus product mapping defined — cannot seed prices from Focus8');
+  }
+
+  const priceBookRecords = await getPriceBookData();
+  if (!priceBookRecords || priceBookRecords.length === 0) {
+    throw new Error('Could not fetch price data from Focus8. Please try again.');
+  }
+
+  const parsedPrice = [];
+  for (const entry of mapping) {
+    const basePrice = getBasePriceFromFocus(entry.focusProductId, priceBookRecords);
+    if (basePrice === null) {
+      throw new Error(`No base price found in Focus8 for volume "${entry.volume}" (focus product ID ${entry.focusProductId})`);
+    }
+    parsedPrice.push({ volume: entry.volume, refId: 'All', price: basePrice });
+  }
+
+  await productOfferModel.updateOne(
+    { _id: product._id },
+    { $set: { price: parsedPrice } }
+  );
+
+  await processProductCatlogPrices(product._id, parsedPrice);
+
+  logger.info(`FOCUS8 :: Seeded ${parsedPrice.length} prices for product ${product._id}`);
+  return parsedPrice;
 };
 
 exports.getProductCatlogs = async (req, res) => {
@@ -509,143 +502,87 @@ exports.searchProductCatlog = async (req, res) => {
 
 exports.updateProductCatlog = async (req, res) => {
   try {
-    const { price, focusProductId, focusUnitId, focusProductMapping, productCategory } = req.body;
-    const existingProductCatlog = await productOfferModel.findOne({
+    const { focusProductId, focusUnitId, focusProductMapping, productCategory } = req.body;
+
+    const duplicate = await productOfferModel.findOne({
       productOfferDescription: req.body.productDescription,
-      _id: { $ne: req.params.id }
+      _id: { $ne: req.params.id },
     });
-    if (existingProductCatlog) {
-      return res.status(400).json({ message: 'Product catlog with the same description already exists.' });
+    if (duplicate) {
+      return res.status(400).json({ message: 'Product catalog with the same description already exists.' });
     }
 
-    // Check if an image is being uploaded
     if (req.body.productImage) {
       if (req.body.productImageUrl) {
-        let imgUrlSplit = req.body.productImageUrl.split('/').pop();
-        const paramsRemove = {
-          Bucket: process.env.AWS_BUCKET_PRODUCT_CATEGORY,
-          Key: imgUrlSplit,
-        };
-        await s3.deleteObject(paramsRemove).promise();
+        const key = req.body.productImageUrl.split('/').pop();
+        await s3.deleteObject({ Bucket: process.env.AWS_BUCKET_PRODUCT_CATEGORY, Key: key }).promise();
       }
-
-      // Decode the base64 image and upload it to S3
       const imageData = await decodeBase64Image(req.body.productImage);
-      const params = {
+      const s3Data = await s3.upload({
         Bucket: process.env.AWS_BUCKET_PRODUCT_CATEGORY,
         Key: `${req.params.id}.png`,
         Body: imageData.data,
         ContentType: imageData.type,
-        ACL: 'public-read'
-      };
-
-      const data = await s3.upload(params).promise();
-      req.body.productImageUrl = data.Location;
+        ACL: 'public-read',
+      }).promise();
+      req.body.productImageUrl = s3Data.Location;
     }
 
-    // Parse and validate price field
-    let parsedPrice = [];
-    try {
-      const priceData = typeof price === 'string' ? JSON.parse(price) : price;
-
-      if (typeof priceData !== 'object' || priceData === null) {
-        throw new Error('Price data must be an object');
-      }
-
-      // Transform the price data to match the schema
-      for (const [volume, priceEntries] of Object.entries(priceData)) {
-        if (!Array.isArray(priceEntries)) continue;
-
-        priceEntries.forEach(entry => {
-          const [[refId, priceValue]] = Object.entries(entry);
-          if (refId && priceValue !== undefined) {
-            parsedPrice.push({
-              volume,
-              refId,
-              price: Number(priceValue)
-            });
-          }
-        });
-      }
-
-      if (parsedPrice.length === 0) {
-        throw new Error('No valid price entries found');
-      }
-    } catch (error) {
-      console.error('Error parsing price data:', error);
-      return res.status(400).json({ message: 'Invalid price format: ' + error.message });
-    }
-
-    // Parse and validate focusProductMapping if provided
+    // Parse focusProductMapping if supplied; null means "don't re-seed prices"
     let parsedFocusMapping = null;
     if (focusProductMapping) {
       try {
-        const mappingData = typeof focusProductMapping === 'string' 
-          ? JSON.parse(focusProductMapping) 
+        const mappingData = typeof focusProductMapping === 'string'
+          ? JSON.parse(focusProductMapping)
           : focusProductMapping;
 
-        if (!Array.isArray(mappingData)) {
-          throw new Error('focusProductMapping must be an array');
+        if (!Array.isArray(mappingData) || mappingData.length === 0) {
+          throw new Error('focusProductMapping must be a non-empty array');
         }
 
-        // Validate mapping structure
-        parsedFocusMapping = mappingData.map(mapping => {
-          if (!mapping.volume || !mapping.focusProductId) {
+        parsedFocusMapping = mappingData.map(m => {
+          if (!m.volume || !m.focusProductId) {
             throw new Error('Each mapping must have volume and focusProductId');
           }
           return {
-            volume: mapping.volume,
-            focusProductId: Number(mapping.focusProductId),
-            focusUnitId: mapping.focusUnitId ? Number(mapping.focusUnitId) : 1
+            volume: m.volume,
+            focusProductId: Number(m.focusProductId),
+            focusUnitId: m.focusUnitId ? Number(m.focusUnitId) : 1,
           };
         });
 
-        // Validate that all volumes in price have corresponding mapping
-        const priceVolumes = [...new Set(parsedPrice.map(p => p.volume))];
-        const mappingVolumes = parsedFocusMapping.map(m => m.volume);
-        const missingVolumes = priceVolumes.filter(v => !mappingVolumes.includes(v));
-        
-        if (missingVolumes.length > 0) {
-          throw new Error(`Missing focus product mapping for volumes: ${missingVolumes.join(', ')}`);
-        }
-
-        // Check for duplicate volumes in mapping
         const volumeCounts = {};
-        mappingVolumes.forEach(v => {
-          volumeCounts[v] = (volumeCounts[v] || 0) + 1;
-        });
+        parsedFocusMapping.forEach(m => { volumeCounts[m.volume] = (volumeCounts[m.volume] || 0) + 1; });
         const duplicates = Object.keys(volumeCounts).filter(v => volumeCounts[v] > 1);
         if (duplicates.length > 0) {
-          throw new Error(`Duplicate volumes in focus product mapping: ${duplicates.join(', ')}`);
+          throw new Error(`Duplicate volumes in mapping: ${duplicates.join(', ')}`);
         }
       } catch (error) {
-        console.error('Error parsing focus product mapping:', error);
-        return res.status(400).json({ message: 'Invalid focus product mapping: ' + error.message });
+        return res.status(400).json({ message: 'Invalid focusProductMapping: ' + error.message });
       }
     }
 
-    // Prepare update data
     const updateData = {
       productOfferDescription: req.body.productDescription,
       productOfferStatus: req.body.productStatus,
-      price: parsedPrice,
       updatedBy: req.body.updatedBy,
       productCategory: productCategory || null,
       focusProductId: focusProductId ? Number(focusProductId) : null,
-      focusUnitId: focusUnitId ? Number(focusUnitId) : null
+      focusUnitId: focusUnitId ? Number(focusUnitId) : null,
     };
 
-    // Add focusProductMapping if provided
     if (parsedFocusMapping !== null) {
       updateData.focusProductMapping = parsedFocusMapping;
     }
 
-    // Add image URL if it was updated
     if (req.body.productImageUrl) {
       updateData.productOfferImageUrl = req.body.productImageUrl;
     }
 
-    // Update the product catalog
+    // Capture old prices before update for rollback on seed failure
+    const before = await productOfferModel.findById(req.params.id).select('price');
+    const oldPrice = before?.price ?? [];
+
     const productCatlog = await productOfferModel.findByIdAndUpdate(
       req.params.id,
       updateData,
@@ -656,19 +593,23 @@ exports.updateProductCatlog = async (req, res) => {
       return res.status(404).json({ message: 'Product catalog not found' });
     }
 
-    // Update the product prices
-    await processProductCatlogPrices(req.params.id, parsedPrice);
+    if (parsedFocusMapping !== null) {
+      try {
+        await seedPricesFromFocus(productCatlog);
+      } catch (seedErr) {
+        // Restore old prices so the product stays consistent
+        await productOfferModel.updateOne({ _id: req.params.id }, { $set: { price: oldPrice } }).catch(() => {});
+        return res.status(502).json({ message: seedErr.message });
+      }
+    }
 
     return res.status(200).json({ data: productCatlog });
   } catch (error) {
     console.log(error);
-    if (error instanceof multer.MulterError) {
-      if (error.code === 'LIMIT_FILE_SIZE') {
-        return res.status(400).json({ error: 'File size exceeds 4 MB!' });
-      }
-    } else {
-      return res.status(500).json({ message: error.message });
+    if (error instanceof multer.MulterError && error.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({ error: 'File size exceeds 4 MB!' });
     }
+    return res.status(500).json({ message: error.message });
   }
 };
 
@@ -682,5 +623,50 @@ exports.deleteProductCatlog = async (req, res) => {
     res.status(200).json({ message: 'Product catlog deleted successfully' });
   } catch (error) {
     res.status(500).json({ message: error.message });
+  }
+};
+
+// Sync prices for a single product from Focus8 pricebook
+exports.syncProductPrices = async (req, res) => {
+  try {
+    const product = await productOfferModel.findById(req.params.id);
+    if (!product) return res.status(404).json({ message: 'Product not found' });
+    const seeded = await seedPricesFromFocus(product);
+    return res.status(200).json({ success: true, pricesSynced: seeded.length });
+  } catch (error) {
+    logger.error('Error syncing product prices', { id: req.params.id, error: error.message });
+    return res.status(502).json({ message: error.message });
+  }
+};
+
+// Sync prices for all products that have a focusProductMapping
+exports.syncAllProductPrices = async (req, res) => {
+  try {
+    const products = await productOfferModel.find({
+      'focusProductMapping.0': { $exists: true },
+    });
+
+    let synced = 0;
+    let skipped = 0;
+    const errors = [];
+
+    for (const product of products) {
+      try {
+        await seedPricesFromFocus(product);
+        synced++;
+      } catch (err) {
+        skipped++;
+        errors.push(`${product.productOfferDescription}: ${err.message}`);
+        logger.warn('FOCUS8 :: Skipped product during sync-all', {
+          productId: product._id,
+          error: err.message,
+        });
+      }
+    }
+
+    return res.status(200).json({ success: true, synced, skipped, errors });
+  } catch (error) {
+    logger.error('Error in syncAllProductPrices', { error: error.message });
+    return res.status(500).json({ message: error.message });
   }
 };

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -197,8 +197,8 @@ const getProductsByName = async (req, res) => {
         $addFields: {
           brandObjId: {
             $cond: {
-              if: { $regexMatch: { input: "$brandId", regex: /^[0-9a-fA-F]{24}$/ } },
-              then: { $toObjectId: "$brandId" },
+              if: { $regexMatch: { input: { $toString: "$brandId" }, regex: /^[0-9a-fA-F]{24}$/ } },
+              then: { $toObjectId: { $toString: "$brandId" } },
               else: null
             }
           }
@@ -293,8 +293,8 @@ const getFocusWarehouses = async (req, res) => {
 
 const getFocusBranches = async (req, res) => {
   try {
-    const warehouses = await getBranchMaster();
-    return res.status(200).json({ success: true, warehouses });
+    const branches = await getBranchMaster();
+    return res.status(200).json({ success: true, branches });
   } catch (error) {
     console.error('Error fetching branches from Focus8', { message: error.message });
     return res.status(500).json({ success: false, message: error.message });

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -293,8 +293,8 @@ const getFocusWarehouses = async (req, res) => {
 
 const getFocusBranches = async (req, res) => {
   try {
-    const warehouses = await getBranchMaster();
-    return res.status(200).json({ success: true, warehouses });
+    const branches = await getBranchMaster();
+    return res.status(200).json({ success: true, branches });
   } catch (error) {
     console.error('Error fetching branches from Focus8', { message: error.message });
     return res.status(500).json({ success: false, message: error.message });

--- a/middleware/authorize.js
+++ b/middleware/authorize.js
@@ -25,12 +25,14 @@ function requireRole(...allowed) {
 
 // Commonly-used role groups.
 const ADMIN = ['SuperUser'];
-const STAFF = ['SuperUser', 'SalesExecutive'];
+const STAFF = ['SuperUser', 'SalesExecutive', 'ProductionManager'];
 const ORDER_CREATORS = ['SuperUser', 'SalesExecutive', 'Dealer'];
+const ORDER_EDITORS = ['SuperUser', 'ProductionManager'];
 
 module.exports = {
     requireRole,
     ADMIN,
     STAFF,
     ORDER_CREATORS,
+    ORDER_EDITORS,
 };

--- a/models/Brand.js
+++ b/models/Brand.js
@@ -5,6 +5,10 @@ const brandSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
+  description: {
+    type: String,
+    default: '',
+  },
 });
 
 const Brand = mongoose.model('Brand', brandSchema);

--- a/models/Order.js
+++ b/models/Order.js
@@ -49,7 +49,9 @@ const orderSchema = new Schema({
   // Status History
   statusHistory: [{
     status: { type: String, required: true },
-    changedAt: { type: Date, default: Date.now }
+    changedAt: { type: Date, default: Date.now },
+    changedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    remarks: { type: String }
   }],
 
   // Sales order context (user-selected in mobile app)

--- a/models/ProductCategory.js
+++ b/models/ProductCategory.js
@@ -1,7 +1,8 @@
 const mongoose = require('mongoose');
 
 const productCategorySchema = new mongoose.Schema({
-    name: { type: String, required: true, unique: true }
+    name: { type: String, required: true, unique: true },
+    description: { type: String, default: '' },
 }, { timestamps: true });
 
 const ProductCategory = mongoose.model('ProductCategory', productCategorySchema);

--- a/models/User.js
+++ b/models/User.js
@@ -28,6 +28,14 @@ const userSchema = new mongoose.Schema({
     productCategories: [{ type: Schema.Types.ObjectId, ref: 'ProductCategory' }]
 }, {timestamps: true})
 
+userSchema.pre('save', function (next) {
+    const VALID_ACCOUNT_TYPES = ['Painter', 'Dealer', 'SalesExecutive', 'SuperUser', 'ProductionManager'];
+    if (this.accountType && !VALID_ACCOUNT_TYPES.includes(this.accountType)) {
+        return next(new Error(`Invalid accountType. Must be one of: ${VALID_ACCOUNT_TYPES.join(', ')}`));
+    }
+    next();
+});
+
 const User = mongoose.model('User', userSchema);
 
 module.exports = User;

--- a/models/deals.model.js
+++ b/models/deals.model.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const dealsSchema = new mongoose.Schema({
+    title:          { type: String, required: true, trim: true, maxlength: 120 },
+    description:    { type: String, trim: true, maxlength: 1000 },
+    dealImageUrl:   { type: String, required: true },
+    expirationDate: { type: Date, required: true },
+    active:         { type: Boolean, required: true, default: true },
+    category:       { type: Schema.Types.ObjectId, ref: 'ProductCategory', required: true },
+    createdBy:      { type: String },
+    updatedBy:      { type: String },
+}, { timestamps: true });
+
+// Compound index powers the per-dealer active-deals query.
+dealsSchema.index({ active: 1, expirationDate: 1, category: 1 });
+
+const Deal = mongoose.model('Deal', dealsSchema, 'deals');
+
+module.exports = Deal;

--- a/routes/deals.route.js
+++ b/routes/deals.route.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const passport = require('passport');
+const router = express.Router();
+const dealsController = require('../controllers/deals.controller');
+const { requireRole, ADMIN } = require('../middleware/authorize');
+
+// All deals routes require a valid JWT.
+router.use(passport.authenticate('jwt', { session: false }));
+
+// Mobile/dealer-facing endpoint — any authenticated user can call it; the
+// controller filters server-side by req.user.productCategories.
+router.get('/active', dealsController.getActiveDealsForUser);
+
+// Admin-only management routes.
+router.get('/', requireRole(ADMIN), dealsController.getDeals);
+router.post('/', requireRole(ADMIN), dealsController.createDeal);
+router.get('/:id', requireRole(ADMIN), dealsController.getDealById);
+router.put('/:id', requireRole(ADMIN), dealsController.updateDeal);
+router.delete('/:id', requireRole(ADMIN), dealsController.deleteDeal);
+
+module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -20,6 +20,7 @@ const orderRoutes = require('./orderRoutes.js');
 const chartRoutes = require('./chartRoutes');
 const creditNoteRoutes = require('./creditNote.route');
 const productCategoryRoutes = require('./productCategoryRoutes');
+const dealsRoutes = require('./deals.route');
 
 /** GET /health-check - Check service health */
 router.get('/health-check', (req, res) => res.send('OK'));
@@ -44,5 +45,6 @@ router.use('/order', orderRoutes);
 router.use('/chart', chartRoutes);
 router.use('/creditNotes', creditNoteRoutes);
 router.use('/productCategories', productCategoryRoutes);
+router.use('/deals', dealsRoutes);
 
 module.exports = router;

--- a/routes/orderRoutes.js
+++ b/routes/orderRoutes.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const passport = require("passport");
 const orderController = require("../controllers/ordersController");
-const { requireRole, ADMIN, STAFF, ORDER_CREATORS } = require('../middleware/authorize');
+const { requireRole, ADMIN, STAFF, ORDER_CREATORS, ORDER_EDITORS } = require('../middleware/authorize');
 
 router.use(passport.authenticate('jwt', { session: false }));
 
@@ -11,6 +11,7 @@ router.post('/orders', orderController.getOrders);
 router.get('/details/:orderId', orderController.getOrderDetails);
 router.get('/dealers', requireRole(STAFF), orderController.getOrderDealers);
 router.put('/updateOrderStatus', requireRole(STAFF), orderController.updateOrderStatus);
+router.put('/updateOrderStatusManual', requireRole(ORDER_EDITORS), orderController.updateOrderStatusManual);
 router.post('/retryFocusSync', requireRole(ADMIN), orderController.retryFocusSync);
 
 module.exports = router;

--- a/routes/productCatlogRoutes.js
+++ b/routes/productCatlogRoutes.js
@@ -19,4 +19,8 @@ router.put('/update/:id', upload.none(), productCatlogController.updateProductCa
 
 router.delete('/delete/:id', productCatlogController.deleteProductCatlog);
 
+router.put('/syncPrices/:id', productCatlogController.syncProductPrices);
+
+router.put('/syncAllPrices', productCatlogController.syncAllProductPrices);
+
 module.exports = router;

--- a/tests/controllers/deals.controller.test.js
+++ b/tests/controllers/deals.controller.test.js
@@ -1,0 +1,186 @@
+const mongoose = require('mongoose');
+
+// Mock AWS S3 client
+jest.mock('../../config/aws', () => ({
+    upload: jest.fn().mockReturnValue({ promise: jest.fn().mockResolvedValue({ Location: 'mock-url' }) }),
+    deleteObject: jest.fn().mockReturnValue({ promise: jest.fn().mockResolvedValue({}) }),
+}));
+
+// Mock the AWS SDK
+jest.mock('aws-sdk', () => ({
+    config: { update: jest.fn() },
+    S3: jest.fn().mockImplementation(() => ({})),
+}));
+
+// Mock the models
+jest.mock('../../models/deals.model');
+jest.mock('../../models/User');
+jest.mock('../../utils/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+}));
+
+const Deal = require('../../models/deals.model');
+const UserModel = require('../../models/User');
+const { getActiveDealsForUser, createDeal, updateDeal, deleteDeal } = require('../../controllers/deals.controller');
+
+function makeRes() {
+    return {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+    };
+}
+
+describe('DealsController', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    describe('getActiveDealsForUser', () => {
+        test('returns deals filtered by active=true, not-expired, and user category $in', async () => {
+            const userId = new mongoose.Types.ObjectId();
+            const cat1 = new mongoose.Types.ObjectId();
+            const cat2 = new mongoose.Types.ObjectId();
+
+            UserModel.findById.mockReturnValue({
+                select: jest.fn().mockReturnValue({
+                    lean: jest.fn().mockResolvedValue({ productCategories: [cat1, cat2] }),
+                }),
+            });
+
+            const mockDeals = [{ _id: 'd1', title: 'Deal 1' }];
+            Deal.find.mockReturnValue({
+                select: jest.fn().mockReturnValue({
+                    sort: jest.fn().mockReturnValue({
+                        lean: jest.fn().mockResolvedValue(mockDeals),
+                    }),
+                }),
+            });
+
+            const req = { user: { _id: userId } };
+            const res = makeRes();
+            await getActiveDealsForUser(req, res);
+
+            expect(Deal.find).toHaveBeenCalledWith(expect.objectContaining({
+                active: true,
+                expirationDate: { $gte: expect.any(Date) },
+                category: { $in: [cat1, cat2] },
+            }));
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith(mockDeals);
+        });
+
+        test('returns [] when user has no productCategories', async () => {
+            UserModel.findById.mockReturnValue({
+                select: jest.fn().mockReturnValue({
+                    lean: jest.fn().mockResolvedValue({ productCategories: [] }),
+                }),
+            });
+
+            const req = { user: { _id: new mongoose.Types.ObjectId() } };
+            const res = makeRes();
+            await getActiveDealsForUser(req, res);
+
+            expect(Deal.find).not.toHaveBeenCalled();
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith([]);
+        });
+
+        test('returns [] when user has missing productCategories field', async () => {
+            UserModel.findById.mockReturnValue({
+                select: jest.fn().mockReturnValue({
+                    lean: jest.fn().mockResolvedValue({}),
+                }),
+            });
+
+            const req = { user: { _id: new mongoose.Types.ObjectId() } };
+            const res = makeRes();
+            await getActiveDealsForUser(req, res);
+
+            expect(Deal.find).not.toHaveBeenCalled();
+            expect(res.json).toHaveBeenCalledWith([]);
+        });
+    });
+
+    describe('createDeal', () => {
+        test('rejects when title is missing', async () => {
+            const req = {
+                user: { _id: new mongoose.Types.ObjectId(), mobile: '9999999999' },
+                body: {
+                    expirationDate: '2099-01-01',
+                    category: new mongoose.Types.ObjectId(),
+                    dealImage: 'data:image/png;base64,xxx',
+                },
+            };
+            const res = makeRes();
+            await createDeal(req, res);
+            expect(res.status).toHaveBeenCalledWith(400);
+            expect(res.json).toHaveBeenCalledWith({ message: 'title, expirationDate and category are required' });
+        });
+
+        test('rejects when dealImage is missing', async () => {
+            const req = {
+                user: { _id: new mongoose.Types.ObjectId(), mobile: '9999999999' },
+                body: {
+                    title: 'Spring Sale',
+                    expirationDate: '2099-01-01',
+                    category: new mongoose.Types.ObjectId(),
+                },
+            };
+            const res = makeRes();
+            await createDeal(req, res);
+            expect(res.status).toHaveBeenCalledWith(400);
+            expect(res.json).toHaveBeenCalledWith({ message: 'Image is required' });
+        });
+    });
+
+    describe('updateDeal', () => {
+        test('preserves dealImageUrl when no new dealImage provided', async () => {
+            const id = new mongoose.Types.ObjectId();
+            const existing = { _id: id, dealImageUrl: 'https://old.example/x.png' };
+
+            Deal.findById.mockResolvedValue(existing);
+            Deal.findByIdAndUpdate.mockReturnValue({
+                populate: jest.fn().mockResolvedValue({ ...existing, title: 'Updated' }),
+            });
+
+            const req = {
+                params: { id: id.toString() },
+                user: { _id: new mongoose.Types.ObjectId(), mobile: '9999999999' },
+                body: { title: 'Updated' },
+            };
+            const res = makeRes();
+            await updateDeal(req, res);
+
+            // Make sure $set didn't include dealImageUrl (it would change the live image).
+            expect(Deal.findByIdAndUpdate).toHaveBeenCalledWith(
+                id.toString(),
+                expect.not.objectContaining({ dealImageUrl: expect.anything() }),
+                expect.any(Object),
+            );
+            expect(res.status).toHaveBeenCalledWith(200);
+        });
+    });
+
+    describe('deleteDeal', () => {
+        test('succeeds even when S3 delete throws', async () => {
+            const id = new mongoose.Types.ObjectId();
+            Deal.findById.mockResolvedValue({ _id: id });
+
+            // Force the S3 deleteObject promise to reject.
+            const s3 = require('../../config/aws');
+            s3.deleteObject.mockReturnValue({
+                promise: jest.fn().mockRejectedValue(new Error('boom')),
+            });
+
+            Deal.findByIdAndDelete.mockResolvedValue({ _id: id });
+
+            const req = { params: { id: id.toString() } };
+            const res = makeRes();
+            await deleteDeal(req, res);
+
+            expect(Deal.findByIdAndDelete).toHaveBeenCalledWith(id.toString());
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith({ message: 'Deal deleted successfully' });
+        });
+    });
+});

--- a/tests/controllers/ordersController.test.js
+++ b/tests/controllers/ordersController.test.js
@@ -765,7 +765,7 @@ describe('getOrderDetails', () => {
         expect(order.status).toBe('DISPATCHED');
     });
 
-    test('enriches items with IN-PARCEL status when qty partially delivered', async () => {
+    test('enriches items with PARTIALLY_DISPATCHED status when qty partially delivered', async () => {
         const syncedOrder = {
             ...baseOrder,
             focusSyncStatus: 'SUCCESS',
@@ -786,8 +786,8 @@ describe('getOrderDetails', () => {
         await ordersController.getOrderDetails(req, res);
 
         const { order } = res.json.mock.calls[0][0];
-        expect(order.items[0].dispatchStatus).toBe('IN-PARCEL');
-        expect(order.status).toBe('IN-PARCEL');
+        expect(order.items[0].dispatchStatus).toBe('PARTIALLY_DISPATCHED');
+        expect(order.status).toBe('PARTIALLY_DISPATCHED');
     });
 
     test('persists derived status to DB when status changes', async () => {


### PR DESCRIPTION
## Summary
- New `deals` resource separate from Product Offers.
- Admin CRUD at `/api/deals`, mobile-facing `/api/deals/active` filtered server-side by dealer's `productCategories`.
- Image upload to S3 bucket `AWS_BUCKET_DEALS` with fixed `${id}.png` key.
- Controller hardened with input validation: invalid ObjectId returns 400, invalid image data returns 400 (not 500), S3 failure on create cleans up the orphan doc, `BUCKET` startup warning if env var is unset, shared `buildS3UploadParams` helper.

## Required env var
Ops must add this to production before merge:
```
AWS_BUCKET_DEALS=<bucket-name>
```
Without it, every create/update will fail at S3 upload time. The controller logs a warning at module load when this is missing.

## Test plan
- [x] `npx jest tests/controllers/deals.controller.test.js` — 7 tests pass (run with `NODE_OPTIONS="--no-experimental-webstorage"` on Node 25)
- [ ] `GET /api/deals/active` without auth returns 401
- [ ] `POST /api/deals` as a Dealer returns 403
- [ ] `POST /api/deals` as a SuperUser creates a deal with an image URL
- [ ] `GET /api/deals/active` as a Dealer in the matching category returns the deal
- [ ] `GET /api/deals/active` as a Dealer in a different category returns []
- [ ] `GET /api/deals/active` as a Dealer with no productCategories returns []
- [ ] `PUT /api/deals/<valid-id>` with no dealImage in body preserves `dealImageUrl`
- [ ] `DELETE /api/deals/<id>` succeeds even when S3 delete fails (best-effort cleanup)
- [ ] `:id` malformed returns 400, not 500

## Spec & Plan
- Spec: `docs/superpowers/specs/2026-05-18-deals-feature-design.md` (in parent `aultra_paints/` dir)
- Plan: `docs/superpowers/plans/2026-05-18-deals-feature.md` (same dir)

## Notes
- Branched on top of `feat/raise-json-body-limit` (PR #155) because Deals depends on the raised 8mb body limit for 5MB image uploads.
- Pre-existing bug observed in `config/aws.js` (uses implicit global `config` set up by `app.js` — works at runtime but breaks bare `node -e` invocations). Out of scope for this PR.

Generated with [Claude Code](https://claude.com/claude-code)
